### PR TITLE
Proj 270 get feeder resolve all references

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 
 ##### New Features
 * AssignToFeeders and AssociatedTerminalTrace are now available for use.
+* PowerTransformerInfo class added. A PowerTransformer may have a PowerTransformerInfo as its asset_info.
 
 ##### Enhancements
 * None.

--- a/changelog.md
+++ b/changelog.md
@@ -2,10 +2,30 @@
 
 ##### Breaking Changes
 * ConnectivityResult __init__ signature has slight changes to simplify use.
+* Removed NetworkProtoToCim. Use NetworkService.add_from_pb directly instead.
+* UUID is no longer a supported type for `IdentifiedObject.mRID`, use a string representation instead.
+* `get_unresolved_reference_mrids` has now been replaced by `get_unresolved_references_from` and `get_unresolved_references_to`, which return `UnresolvedReference`s
 
 ##### New Features
 * AssignToFeeders and AssociatedTerminalTrace are now available for use.
 * PowerTransformerInfo class added. A PowerTransformer may have a PowerTransformerInfo as its asset_info.
+* `BaseService` now has two mappings over `UnresolvedReference`, via the to_mrid and the from objects mrid, and two functions have been added: 
+    - `get_unresolved_references_from(mrid)`: Allows fetching all UnresolvedReferences from `mrid`
+    - `get_unresolved_references_to(mrid)`: Allows fetching all UnresolvedReferences pointing to `mrid`
+* NetworkConsumerClient has 4 new functions:
+    - For fetching equipment for an EquipmentContainer
+            
+          get_equipment_for_container(service: NetworkService, mrid: str)         
+    - For fetching current equipment for a Feeder
+      
+          get_current_equipment_for_feeder(service: NetworkService, mrid: str)
+    - For fetching equipment for an OperationalRestriction
+      
+          get_equipment_for_restriction(service: NetworkService, mrid: str)
+    - For fetching terminals for a ConnectivityNode
+      
+          get_terminals_for_connectivitynode(service: NetworkService, mrid: str)
+* `NetworkConsumerClient.get_feeder()` now resolves all references, and thus you can expect to receive a Feeder with all equipment and their associations populated.
 
 ##### Enhancements
 * None.

--- a/docs/docs/consumer.mdx
+++ b/docs/docs/consumer.mdx
@@ -85,7 +85,15 @@ async def get_with_base_voltage(service: NetworkService, client: NetworkConsumer
     if not equipment:
         return
 
-    mrids = service.get_unresolved_reference_mrids(resolver.ce_base_voltage(equipment))
-    if mrids:
-        await client.get_identified_object(service, mrids[0])
+    # Get all unresolved references
+    for mrid in service.unresolved_mrids():
+        await client.get_identified_object(service, mrid)
+
+    # Or get only unresolved references for `equipment` only:
+    for mrid in service.get_unresolved_reference_mrids_from(equipment):
+        await client.get_identified_object(service, mrid)
+
+    # Or get only unresolved reference mRIDs pointing to `equipment`:
+    for mrid in service.get_unresolved_reference_mrids_to(equipment):
+        await client.get_identified_object(service, mrid)
 ```

--- a/docs/docs/consumer.mdx
+++ b/docs/docs/consumer.mdx
@@ -105,7 +105,7 @@ for ref in service.get_unresolved_references_from(equipment.mrid):
 
 # To get unresolved references pointing to `equipment`:
 for ref in service.get_unresolved_references_to(equipment.mrid):
-    await client.get_identified_object(service, ref.mrid)
+    await client.get_identified_object(service, ref.from_ref.mrid)
 
 # Get all unresolved references. Note this will iterate over every unresolved reference and is likely undesirable. You should prefer to use the above two methods.
 for ref in service.unresolved_references():

--- a/docs/docs/consumer.mdx
+++ b/docs/docs/consumer.mdx
@@ -70,11 +70,16 @@ they wish to use, without needing to pull back large amounts of full object data
 
 ## Requesting Identified Objects
 
-Identified objects can be requested to build a model client side. When identified objects are loaded, any referenced
-objects that have not been previously requested need to be requested explicitly. The exception to this is terminals
-are always sent with their conducting equipment and transformer ends are always sent with transformers.
+:::warning
+The *ConsumerClient APIs will take care of this for you, and you typically only need these functions if you're
+developing the consumer client APIs themselves. Make sure what you want to achieve isn't already covered by the
+API before delving into this code.
+:::
 
-To find the mRIDs of any references that need to be requested you can use the [deferred reference](services.mdx#deferred-references)
+Identified objects can be requested to build a model client side. When identified objects are loaded, any referenced
+objects that have not been previously requested need to be requested explicitly.
+
+To find the references that need to be requested you can use the [deferred reference](services.mdx#deferred-references)
 functions on the service provided when requesting identified objects.
 
 ```python
@@ -85,15 +90,24 @@ async def get_with_base_voltage(service: NetworkService, client: NetworkConsumer
     if not equipment:
         return
 
-    # Get all unresolved references
-    for mrid in service.unresolved_mrids():
-        await client.get_identified_object(service, mrid)
+    # Get all base voltage relationships
+    mrids = service.get_unresolved_reference_mrids_by_resolver(resolver.ce_base_voltage(equipment))
+    if mrids:
+        await client.get_identified_object(service, mrids[0])
+```
 
-    # Or get only unresolved references for `equipment` only:
-    for mrid in service.get_unresolved_reference_mrids_from(equipment):
-        await client.get_identified_object(service, mrid)
+You can also query the services UnresolvedReferences in the following ways:
 
-    # Or get only unresolved reference mRIDs pointing to `equipment`:
-    for mrid in service.get_unresolved_reference_mrids_to(equipment):
-        await client.get_identified_object(service, mrid)
+```python
+# To get unresolved references pointing from `equipment` to other objects:
+for ref in service.get_unresolved_references_from(equipment.mrid):
+    await client.get_identified_object(service, ref.to_mrid)
+
+# To get unresolved references pointing to `equipment`:
+for ref in service.get_unresolved_references_to(equipment.mrid):
+    await client.get_identified_object(service, ref.mrid)
+
+# Get all unresolved references. Note this will iterate over every unresolved reference and is likely undesirable. You should prefer to use the above two methods.
+for ref in service.unresolved_references():
+    await client.get_identified_object(service, ref.to_mrid)
 ```

--- a/docs/docs/services.mdx
+++ b/docs/docs/services.mdx
@@ -186,10 +186,10 @@ from zepben.evolve import NetworkService, Feeder, Breaker, resolver
 
 service = NetworkService()
 
-feeder = Feeder()
+feeder = Feeder("f")
 service.add(feeder)
 
-switch = Breaker()
+switch = Breaker("b1")
 service.add(switch)
 
 # As the switch is already added to the service, this will be resolved immediately.
@@ -197,12 +197,24 @@ service.resolve_or_defer_reference(resolver.ec_equipment(feeder), switch.mrid)
 print(feeder.equipment.contains(switch)) # true
 
 # Now if we try and resolve something not added it will be deferred
-junction = Junction()
+junction = Junction("j1")
 service.resolve_or_defer_reference(resolver.ec_equipment(feeder), junction.mrid)
 print(feeder.equipment.contains(junction)) # false
 
-# We can query the unresolved reference MRIDs back out of the service
-print(service.get_unresolved_reference_mrids(resolver.ec_equipment(feeder))) # [junction]
+# We can query the unresolved reference MRIDs back out of the service using a specific resolver
+print(service.get_unresolved_reference_mrids_by_resolver(resolver.ec_equipment(feeder))) # ["j1"]
+# Or using the mrid of the destination object
+print(service.get_unresolved_reference_mrids_to(feeder.mrid)) # ["j1"]
+# Or using the mrid of the source object
+print(service.get_unresolved_reference_mrids_from(junction.mrid)) # ["f"]
+
+# Or simply loop over all the unresolved references
+for ur in service.unresolved_references():
+    print(f"From: {ur.resolver.from_class} {ur.from_mrid}, To: {ur.resolver.to_class} {ur.to_mrid}")
+
+# Or only their mRIDs (useful for using with a consumer client)
+for mrid in service.unresolved_mrids():
+    print(mrid)
 
 # When the object with the deferred mRID is added, the reference gets resolved
 service.add(junction)

--- a/docs/docs/services.mdx
+++ b/docs/docs/services.mdx
@@ -204,9 +204,9 @@ print(feeder.equipment.contains(junction)) # false
 # We can query the unresolved reference MRIDs back out of the service using a specific resolver
 print(service.get_unresolved_reference_mrids_by_resolver(resolver.ec_equipment(feeder))) # ["j1"]
 # Or using the mrid of the destination object
-print(service.get_unresolved_references_to(feeder.mrid)) # ["j1"]
+print(service.get_unresolved_references_to(feeder.mrid)) # [junction]
 # Or using the mrid of the source object
-print(service.get_unresolved_references_from(junction.mrid)) # ["f"]
+print(service.get_unresolved_references_from(junction.mrid)) # [feeder]
 
 # When the object with the deferred mRID is added, the reference gets resolved
 service.add(junction)

--- a/docs/docs/services.mdx
+++ b/docs/docs/services.mdx
@@ -204,17 +204,9 @@ print(feeder.equipment.contains(junction)) # false
 # We can query the unresolved reference MRIDs back out of the service using a specific resolver
 print(service.get_unresolved_reference_mrids_by_resolver(resolver.ec_equipment(feeder))) # ["j1"]
 # Or using the mrid of the destination object
-print(service.get_unresolved_reference_mrids_to(feeder.mrid)) # ["j1"]
+print(service.get_unresolved_references_to(feeder.mrid)) # ["j1"]
 # Or using the mrid of the source object
-print(service.get_unresolved_reference_mrids_from(junction.mrid)) # ["f"]
-
-# Or simply loop over all the unresolved references
-for ur in service.unresolved_references():
-    print(f"From: {ur.resolver.from_class} {ur.from_mrid}, To: {ur.resolver.to_class} {ur.to_mrid}")
-
-# Or only their mRIDs (useful for using with a consumer client)
-for mrid in service.unresolved_mrids():
-    print(mrid)
+print(service.get_unresolved_references_from(junction.mrid)) # ["f"]
 
 # When the object with the deferred mRID is added, the reference gets resolved
 service.add(junction)

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     install_requires=[
         "protobuf",
         "requests",
-        "zepben.protobuf>=0.11.0b2",
+        "zepben.protobuf>=0.11.0",
         "python-jose-cryptodome",
         "dataclassy"
     ],

--- a/setup.py
+++ b/setup.py
@@ -35,9 +35,9 @@ setup(
     install_requires=[
         "protobuf",
         "requests",
-        "zepben.protobuf>=0.11.0",
+        "zepben.protobuf>=0.12.0b1",
         "python-jose-cryptodome",
-        "dataclassy"
+        "dataclassy==0.6.2"
     ],
     extras_require={
         "test": test_deps,

--- a/src/zepben/evolve/__init__.py
+++ b/src/zepben/evolve/__init__.py
@@ -117,4 +117,4 @@ from zepben.evolve.streaming.grpc.grpc import *
 from zepben.evolve.streaming.grpc.connect import *
 from zepben.evolve.streaming.put.producer import *
 
-
+from zepben.evolve.util import *

--- a/src/zepben/evolve/model/cim/iec61970/base/core/identified_object.py
+++ b/src/zepben/evolve/model/cim/iec61970/base/core/identified_object.py
@@ -31,7 +31,7 @@ class IdentifiedObject(object, metaclass=ABCMeta):
     relation, however must be in snake case to keep the phases PEP compliant.
     """
 
-    mrid: Union[str, UUID] = CopyableUUID()
+    mrid: Union[str] = CopyableUUID()
     """Master resource identifier issued by a model authority. The mRID is unique within an exchange context. 
     Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended."""
 
@@ -40,6 +40,9 @@ class IdentifiedObject(object, metaclass=ABCMeta):
 
     description: str = ""
     """a free human readable text describing or naming the object. It may be non unique and may not correlate to a naming hierarchy."""
+
+    def __init__(self):
+        self.mrid = str(self.mrid)
 
     def __str__(self):
         return f"{self.__class__.__name__}{{{'|'.join(a for a in (str(self.mrid), str(self.name)) if a)}}}"

--- a/src/zepben/evolve/model/cim/iec61970/base/core/identified_object.py
+++ b/src/zepben/evolve/model/cim/iec61970/base/core/identified_object.py
@@ -31,7 +31,7 @@ class IdentifiedObject(object, metaclass=ABCMeta):
     relation, however must be in snake case to keep the phases PEP compliant.
     """
 
-    mrid: Union[str] = CopyableUUID()
+    mrid: str = CopyableUUID()
     """Master resource identifier issued by a model authority. The mRID is unique within an exchange context. 
     Global uniqueness is easily achieved by using a UUID, as specified in RFC 4122, for the mRID. The use of UUID is strongly recommended."""
 
@@ -40,9 +40,6 @@ class IdentifiedObject(object, metaclass=ABCMeta):
 
     description: str = ""
     """a free human readable text describing or naming the object. It may be non unique and may not correlate to a naming hierarchy."""
-
-    def __init__(self):
-        self.mrid = str(self.mrid)
 
     def __str__(self):
         return f"{self.__class__.__name__}{{{'|'.join(a for a in (str(self.mrid), str(self.name)) if a)}}}"

--- a/src/zepben/evolve/services/common/base_service.py
+++ b/src/zepben/evolve/services/common/base_service.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from abc import ABCMeta
 from collections import OrderedDict
 from dataclassy import dataclass
-from typing import Dict, Generator, Callable, Optional, List, Union, Sized
+from typing import Dict, Generator, Callable, Optional, List, Union, Sized, Set, KeysView
 
 from zepben.evolve.services.common.reference_resolvers import BoundReferenceResolver, UnresolvedReference
 
@@ -21,7 +21,35 @@ _GET_DEFAULT = (1,)
 class BaseService(object, metaclass=ABCMeta):
     name: str
     _objectsByType: Dict[type, Dict[str, IdentifiedObject]] = OrderedDict()
-    _unresolved_references: Dict[str, List[UnresolvedReference]] = OrderedDict()
+    _unresolved_references_to: Dict[str, Set[UnresolvedReference]] = OrderedDict()
+    """
+    A dictionary of references between mRID's that as yet have not been resolved - typically when transferring services between systems.
+    THe key is the to_mrid of the `UnresolvedReference`s, and the value is a list of `UnresolvedReference`s for that specific object.
+    For example, if an AcLineSegment with mRID 'acls1' is present in the service, but the service is missing its `location` with mRID 'location-l1' 
+    and `perLengthSequenceImpedance` with mRID 'plsi-1', the following key value pairs would be present:
+    {
+        "plsi-1": [
+          UnresolvedReference(from_mrid='acls1', to_mrid='plsi-1', resolver=ReferenceResolver(from_class=AcLineSegment, to_class=PerLengthSequenceImpedance, resolve=...))
+        ],
+        "location-l1": [
+          UnresolvedReference(from_mrid='acls1', to_mrid='location-l1', resolver=ReferenceResolver(from_class=AcLineSegment, to_class=Location, resolve=...))
+        ]
+    }
+    
+    `resolve` in `ReferenceResolver` will be the `Callable` used to populate the relationship between the `IdentifiedObject`s after they are both added to the
+    service.
+    """
+
+    _unresolved_references_from: Dict[str, Set[UnresolvedReference]] = OrderedDict()
+    """ 
+    An index of the unresolved references by their from_mrid used for lookups only. For the above example this will be a dictionary of the form:
+    {
+        "acls1": [
+          UnresolvedReference(from_mrid='acls1', to_mrid='location-l1', resolver=ReferenceResolver(from_class=AcLineSegment, to_class=Location, resolve=...)),
+          UnresolvedReference(from_mrid='acls1', to_mrid='plsi-1', resolver=ReferenceResolver(from_class=AcLineSegment, to_class=PerLengthSequenceImpedance, resolve=...))
+        ]
+    }
+    """
 
     def __contains__(self, mrid: str) -> bool:
         """
@@ -42,7 +70,7 @@ class BaseService(object, metaclass=ABCMeta):
         """
         Returns True if this service has unresolved references, False otherwise.
         """
-        return len(self._unresolved_references) > 0
+        return len(self._unresolved_references_to) > 0
 
     def len_of(self, t: type = None) -> int:
         """
@@ -57,23 +85,17 @@ class BaseService(object, metaclass=ABCMeta):
     def num_unresolved_references(self):
         """
         Get the total number of unresolved references.
-        Note that this is not terribly cheap call, and should be used sparingly. To test if unresolved references exist,
-        use `has_unresolved_references()` instead.
         Returns The number of references in the network that have not already been resolved.
         """
-        return len({r.to_mrid for reflist in self._unresolved_references.values() for r in reflist})
+        return sum([len(r) for r in self._unresolved_references_to.copy().values()])
 
-    def unresolved_references(self):
-        for from_mrid, unresolved_refs in self._unresolved_references.copy().items():
-            yield from_mrid, unresolved_refs
+    def unresolved_references(self) -> Generator[UnresolvedReference, None, None]:
+        for unresolved_refs in self._unresolved_references_to.copy().values():
+            for ur in unresolved_refs:
+                yield ur
 
-    def unresolved_mrids(self):
-        seen = set()
-        for refs in self._unresolved_references.copy().values():
-            for ref in refs:
-                if ref.to_mrid not in seen:
-                    seen.add(ref.to_mrid)
-                    yield ref.to_mrid
+    def unresolved_mrids(self) -> KeysView[str]:
+        return self._unresolved_references_from.copy().keys()
 
     def get(self, mrid: str, type_: type = None, default=_GET_DEFAULT,
             generate_error: Callable[[str, str], str] = lambda mrid, typ: f"Failed to find {typ}[{mrid}]") -> IdentifiedObject:
@@ -92,7 +114,7 @@ class BaseService(object, metaclass=ABCMeta):
         """
         if not mrid:
             raise KeyError("You must specify an mRID to get. Empty/None is invalid.")
-
+        mrid = str(mrid)
         if type_:
             try:
                 return self._objectsByType[type_][mrid]
@@ -132,26 +154,30 @@ class BaseService(object, metaclass=ABCMeta):
         `identified_object` The object to associate with this service.
         Returns True if the object is associated with this service, False otherwise.
         """
-        if not identified_object.mrid:
+        mrid = str(identified_object.mrid)
+        if not mrid:
             return False
         # TODO: Only allow supported types
 
         objs = self._objectsByType.get(identified_object.__class__, dict())
-        if identified_object.mrid in objs:
+        if mrid in objs:
             return False
 
         # Check other types and make sure this mRID is unique
         for obj_map in self._objectsByType.values():
-            if identified_object.mrid in obj_map:
+            if mrid in obj_map:
                 return False
 
-        unresolved_refs = self._unresolved_references.get(identified_object.mrid, None)
+        unresolved_refs = self._unresolved_references_to.get(mrid, None)
         if unresolved_refs:
             for ref in unresolved_refs:
-                ref.resolver.resolve(ref.from_ref, identified_object)
-            del self._unresolved_references[identified_object.mrid]
+                ref.resolver.resolve(self.get(ref.from_mrid, ref.resolver.from_class), identified_object)
+                self._unresolved_references_from[ref.from_mrid].remove(ref)
+                if not self._unresolved_references_from[ref.from_mrid]:
+                    del self._unresolved_references_from[ref.from_mrid]
+            del self._unresolved_references_to[mrid]
 
-        objs[identified_object.mrid] = identified_object
+        objs[mrid] = identified_object
         self._objectsByType[identified_object.__class__] = objs
         return True
 
@@ -171,31 +197,40 @@ class BaseService(object, metaclass=ABCMeta):
         """
         if not to_mrid:
             return True
-
+        to_mrid = str(to_mrid)
         from_ = bound_resolver.from_obj
         resolver = bound_resolver.resolver
         reverse_resolver = bound_resolver.reverse_resolver
         try:
+            # If to_mrid is present in the service, we resolve any references immediately.
             to = self.get(to_mrid, resolver.to_class)
             resolver.resolve(from_, to)
             if reverse_resolver:
                 reverse_resolver.resolve(to, from_)
 
-                # Clean up any reverse unresolved references now that the reference has been resolved
-                if from_.mrid in self._unresolved_references:
-                    refs = self._unresolved_references[from_.mrid]
-                    self._unresolved_references[from_.mrid] = [ref for ref in refs if not ref.to_mrid == from_.mrid or not ref.resolver == reverse_resolver]
+                # Clean up any reverse resolvers now that the reference has been resolved
+                if from_.mrid in self._unresolved_references_to:
+                    to_remove = UnresolvedReference(from_mrid=to.mrid, to_mrid=from_.mrid, resolver=reverse_resolver)
+                    self._unresolved_references_to[from_.mrid].remove(to_remove)
+                    self._unresolved_references_from[to_remove.from_mrid].remove(to_remove)
+                    if not self._unresolved_references_from[to_remove.from_mrid]:
+                        del self._unresolved_references_from[to_remove.from_mrid]
+                    if not self._unresolved_references_to[from_.mrid]:
+                        del self._unresolved_references_to[from_.mrid]
 
-                    if not self._unresolved_references[from_.mrid]:
-                        del self._unresolved_references[from_.mrid]
             return True
         except KeyError:
-            urefs = self._unresolved_references.get(to_mrid, list())
-            urefs.append(UnresolvedReference(from_ref=from_, to_mrid=to_mrid, resolver=resolver))
-            self._unresolved_references[to_mrid] = urefs
+            # to_mrid didn't exist in the service, populate the reference caches for resolution when it is added.
+            urefs = self._unresolved_references_to.get(to_mrid, set())
+            uref = UnresolvedReference(from_mrid=from_.mrid, to_mrid=to_mrid, resolver=resolver)
+            urefs.add(uref)
+            self._unresolved_references_to[to_mrid] = urefs
+            rev_urefs = self._unresolved_references_from.get(from_.mrid, set())
+            rev_urefs.add(uref)
+            self._unresolved_references_from[from_.mrid] = rev_urefs
             return False
 
-    def get_unresolved_reference_mrids(self, bound_resolvers: Union[BoundReferenceResolver, Sized[BoundReferenceResolver]]) -> Generator[str, None, None]:
+    def get_unresolved_reference_mrids_by_resolver(self, bound_resolvers: Union[BoundReferenceResolver, Sized[BoundReferenceResolver]]) -> Generator[str, None, None]:
         """
         Gets a set of MRIDs that are referenced by the from_obj held by `bound_resolver` that are unresolved.
         `bound_resolver` The `BoundReferenceResolver` to retrieve unresolved references for.
@@ -208,12 +243,33 @@ class BaseService(object, metaclass=ABCMeta):
         except TypeError:
             resolvers = [bound_resolvers]
 
-        for refs in self._unresolved_references.values():
-            for ref in refs:
-                for resolver in resolvers:
-                    if ref.from_ref is resolver.from_obj and ref.to_mrid not in seen and ref.resolver == resolver.resolver:
-                        seen.add(ref.to_mrid)
-                        yield ref.to_mrid
+        for resolver in resolvers:
+            if resolver.from_obj.mrid not in self._unresolved_references_from:
+                continue
+            for ref in self._unresolved_references_from[resolver.from_obj.mrid]:
+                if ref.to_mrid not in seen and ref.resolver == resolver.resolver:
+                    seen.add(ref.to_mrid)
+                    yield ref.to_mrid
+
+    def get_unresolved_reference_mrids_from(self, mrid: str) -> Generator[str, None, None]:
+        """
+        Get the mRIDs that are unresolved that `mrid` has to other objects.
+        `mrid` The mRID to get unresolved references for.
+        Returns a generator over the mRIDs that need to be resolved for `mrid`.
+        """
+        if mrid in self._unresolved_references_from:
+            for ref in self._unresolved_references_from[str(mrid)]:
+                yield ref.to_mrid
+
+    def get_unresolved_reference_mrids_to(self, mrid: str) -> Generator[str, None, None]:
+        """
+        Get the mRIDs that are unresolved that other objects have to `mrid`.
+        `mrid` The mRID to fetch unresolved references for that are pointing to it.
+        Returns a generator over the mRIDs that need to be resolved for `mrid`.
+        """
+        if mrid in self._unresolved_references_to:
+            for ref in self._unresolved_references_to[str(mrid)]:
+                yield ref.from_mrid
 
     def remove(self, identified_object: IdentifiedObject) -> bool:
         """
@@ -222,7 +278,7 @@ class BaseService(object, metaclass=ABCMeta):
         `identified_object` THe object to disassociate from the service.
         Raises `KeyError` if `identified_object` or its type was not present in the service.
         """
-        del self._objectsByType[identified_object.__class__][identified_object.mrid]
+        del self._objectsByType[identified_object.__class__][str(identified_object.mrid)]
         return True
 
     def objects(self, obj_type: Optional[type] = None, exc_types: Optional[List[type]] = None) -> Generator[IdentifiedObject, None, None]:

--- a/src/zepben/evolve/services/common/base_service.py
+++ b/src/zepben/evolve/services/common/base_service.py
@@ -70,7 +70,7 @@ class BaseService(object, metaclass=ABCMeta):
         """
         Returns True if this service has unresolved references, False otherwise.
         """
-        return len(self._unresolved_references_to) > 0
+        return self.num_unresolved_references() > 0
 
     def len_of(self, t: type = None) -> int:
         """
@@ -95,7 +95,7 @@ class BaseService(object, metaclass=ABCMeta):
                 yield ur
 
     def unresolved_mrids(self) -> KeysView[str]:
-        return self._unresolved_references_from.copy().keys()
+        return self._unresolved_references_from.keys() | self._unresolved_references_to.keys()
 
     def get(self, mrid: str, type_: type = None, default=_GET_DEFAULT,
             generate_error: Callable[[str, str], str] = lambda mrid, typ: f"Failed to find {typ}[{mrid}]") -> IdentifiedObject:

--- a/src/zepben/evolve/services/common/base_service.py
+++ b/src/zepben/evolve/services/common/base_service.py
@@ -100,13 +100,6 @@ class BaseService(object, metaclass=ABCMeta):
             for ur in unresolved_refs:
                 yield ur
 
-    def unresolved_mrids(self) -> KeysView[str]:
-        """
-        Returns all mRIDs that are currently unresolved. This should typically be avoided when resolving references in favour of
-        `get_unresolved_reference_mrids_by_resolver()`, `get_unresolved_reference_mrids_from()`, and `get_unresolved_reference_mrids_to()`
-        """
-        return self._unresolved_references_from.keys() | self._unresolved_references_to.keys()
-
     def get(self, mrid: str, type_: type = None, default=_GET_DEFAULT,
             generate_error: Callable[[str, str], str] = lambda mrid, typ: f"Failed to find {typ}[{mrid}]") -> IdentifiedObject:
         """

--- a/src/zepben/evolve/services/common/base_service.py
+++ b/src/zepben/evolve/services/common/base_service.py
@@ -26,29 +26,29 @@ class BaseService(object, metaclass=ABCMeta):
     _unresolved_references_to: Dict[str, Set[UnresolvedReference]] = OrderedDict()
     """
     A dictionary of references between mRID's that as yet have not been resolved - typically when transferring services between systems.
-    THe key is the to_mrid of the `UnresolvedReference`s, and the value is a list of `UnresolvedReference`s for that specific object.
+    The key is the to_mrid of the `UnresolvedReference`s, and the value is a list of `UnresolvedReference`s for that specific object.
     For example, if an AcLineSegment with mRID 'acls1' is present in the service, but the service is missing its `location` with mRID 'location-l1' 
     and `perLengthSequenceImpedance` with mRID 'plsi-1', the following key value pairs would be present:
     {
         "plsi-1": [
-          UnresolvedReference(from_mrid='acls1', to_mrid='plsi-1', resolver=ReferenceResolver(from_class=AcLineSegment, to_class=PerLengthSequenceImpedance, resolve=...))
+          UnresolvedReference(from_ref=AcLineSegment('acls1'), to_mrid='plsi-1', resolver=ReferenceResolver(from_class=AcLineSegment, to_class=PerLengthSequenceImpedance, resolve=...))
         ],
         "location-l1": [
-          UnresolvedReference(from_mrid='acls1', to_mrid='location-l1', resolver=ReferenceResolver(from_class=AcLineSegment, to_class=Location, resolve=...))
+          UnresolvedReference(from_ref=AcLineSegment('acls1'), to_mrid='location-l1', resolver=ReferenceResolver(from_class=AcLineSegment, to_class=Location, resolve=...))
         ]
     }
     
-    `resolve` in `ReferenceResolver` will be the `Callable` used to populate the relationship between the `IdentifiedObject`s after they are both added to the
-    service.
+    `resolve` in `ReferenceResolver` will be the function used to populate the relationship between the `IdentifiedObject`s either when 
+    `resolveOrDeferReference() is called if the other side of the reference exists in the service, or otherwise when the second object is added to the service.
     """
 
     _unresolved_references_from: Dict[str, Set[UnresolvedReference]] = OrderedDict()
     """ 
-    An index of the unresolved references by their from_mrid used for lookups only. For the above example this will be a dictionary of the form:
+    An index of the unresolved references by their `from_ref.mrid`. For the above example this will be a dictionary of the form:
     {
         "acls1": [
-          UnresolvedReference(from_mrid='acls1', to_mrid='location-l1', resolver=ReferenceResolver(from_class=AcLineSegment, to_class=Location, resolve=...)),
-          UnresolvedReference(from_mrid='acls1', to_mrid='plsi-1', resolver=ReferenceResolver(from_class=AcLineSegment, to_class=PerLengthSequenceImpedance, resolve=...))
+          UnresolvedReference(from_ref=AcLineSegment('acls1'), to_mrid='location-l1', resolver=ReferenceResolver(from_class=AcLineSegment, to_class=Location, resolve=...)),
+          UnresolvedReference(from_ref=AcLineSegment('acls1'), to_mrid='plsi-1', resolver=ReferenceResolver(from_class=AcLineSegment, to_class=PerLengthSequenceImpedance, resolve=...))
         ]
     }
     """

--- a/src/zepben/evolve/services/common/base_service.py
+++ b/src/zepben/evolve/services/common/base_service.py
@@ -8,10 +8,10 @@ from __future__ import annotations
 from abc import ABCMeta
 from collections import OrderedDict
 from dataclassy import dataclass
-from typing import Dict, Generator, Callable, Optional, List, Union, Sized, Set, KeysView, Type
+from typing import Dict, Generator, Callable, Optional, List, Union, Sized, Set
 
 from zepben.evolve.model.cim.iec61970.base.core.identified_object import IdentifiedObject
-from zepben.evolve.services.common.reference_resolvers import BoundReferenceResolver, UnresolvedReference, Relationship
+from zepben.evolve.services.common.reference_resolvers import BoundReferenceResolver, UnresolvedReference
 
 __all__ = ["BaseService"]
 
@@ -82,7 +82,17 @@ class BaseService(object, metaclass=ABCMeta):
         if t is None:
             return sum([len(vals) for vals in self._objectsByType.values()])
         else:
-            return len(self._objectsByType[t].values())
+            try:
+                return len(self._objectsByType[t].values())
+            except KeyError:
+                count = 0
+                for c, obj_map in self._objectsByType.items():
+                    if issubclass(c, t):
+                        try:
+                            count += len(self._objectsByType[c].values())
+                        except KeyError:
+                            pass
+                return count
 
     def num_unresolved_references(self):
         """

--- a/src/zepben/evolve/services/common/reference_resolvers.py
+++ b/src/zepben/evolve/services/common/reference_resolvers.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 from dataclassy import dataclass
-from typing import Callable, Optional
+from typing import Callable, Optional, Type
 
 from zepben.evolve.model.cim.iec61968.assetinfo.power_transformer_info import PowerTransformerInfo
 from zepben.evolve.model.cim.iec61968.assetinfo.wire_info import WireInfo
@@ -61,7 +61,7 @@ __all__ = ["acls_to_plsi_resolver", "asset_to_asset_org_role_resolver", "asset_t
            "sub_to_circuit_resolver", "sub_to_eloop_resolver", "sub_to_loop_resolver", "term_to_ce_resolver", "term_to_cn_resolver", "te_to_term_resolver",
            "te_to_bv_resolver", "te_to_rtc_resolver", "up_to_ed_resolver", "up_to_eq_resolver", "up_to_loc_resolver", "circuit_to_loop_resolver",
            "circuit_to_sub_resolver", "circuit_to_term_resolver", "loop_to_circuit_resolver", "loop_to_esub_resolver", "loop_to_sub_resolver",
-           "BoundReferenceResolver", "ReferenceResolver", "UnresolvedReference"]
+           "BoundReferenceResolver", "ReferenceResolver", "UnresolvedReference", "Relationship"]
 
 @dataclass(frozen=True, eq=False, slots=True)
 class ReferenceResolver(object):
@@ -125,6 +125,16 @@ class UnresolvedReference(object):
 
     def __hash__(self):
         return hash((type(self), self.from_mrid, self.to_mrid, self.resolver))
+
+    @property
+    def relationship(self) -> Relationship:
+        return Relationship(self.resolver.from_class, self.resolver.to_class)
+
+
+@dataclass(frozen=True, slots=True)
+class Relationship(object):
+    from_class: Type
+    to_class: Type
 
 
 def _resolve_ce_term(ce, t):

--- a/src/zepben/evolve/services/common/reference_resolvers.py
+++ b/src/zepben/evolve/services/common/reference_resolvers.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 from dataclassy import dataclass
-from typing import Callable, Optional, Type
+from typing import Callable, Optional
 
 from zepben.evolve.model.cim.iec61968.assetinfo.power_transformer_info import PowerTransformerInfo
 from zepben.evolve.model.cim.iec61968.assetinfo.wire_info import WireInfo
@@ -61,7 +61,7 @@ __all__ = ["acls_to_plsi_resolver", "asset_to_asset_org_role_resolver", "asset_t
            "sub_to_circuit_resolver", "sub_to_eloop_resolver", "sub_to_loop_resolver", "term_to_ce_resolver", "term_to_cn_resolver", "te_to_term_resolver",
            "te_to_bv_resolver", "te_to_rtc_resolver", "up_to_ed_resolver", "up_to_eq_resolver", "up_to_loc_resolver", "circuit_to_loop_resolver",
            "circuit_to_sub_resolver", "circuit_to_term_resolver", "loop_to_circuit_resolver", "loop_to_esub_resolver", "loop_to_sub_resolver",
-           "BoundReferenceResolver", "ReferenceResolver", "UnresolvedReference", "Relationship"]
+           "BoundReferenceResolver", "ReferenceResolver", "UnresolvedReference"]
 
 @dataclass(frozen=True, eq=False, slots=True)
 class ReferenceResolver(object):

--- a/src/zepben/evolve/services/common/reference_resolvers.py
+++ b/src/zepben/evolve/services/common/reference_resolvers.py
@@ -115,8 +115,10 @@ class UnresolvedReference(object):
     from_ref: IdentifiedObject
     to_mrid: str
     resolver: ReferenceResolver
+    reverse_resolver: Optional[ReferenceResolver] = None
 
     def __eq__(self, other: UnresolvedReference):
+        # we don't check reverse resolver for equality, as it doesn't make sense to have a reverse resolver that is not the reverse of resolver
         return self.from_ref.mrid == other.from_ref.mrid and self.to_mrid == other.to_mrid and self.resolver == other.resolver
 
     def __ne__(self, other: UnresolvedReference):

--- a/src/zepben/evolve/services/common/reference_resolvers.py
+++ b/src/zepben/evolve/services/common/reference_resolvers.py
@@ -125,16 +125,6 @@ class UnresolvedReference(object):
     def __hash__(self):
         return hash((type(self), self.from_ref.mrid, self.to_mrid, self.resolver))
 
-    @property
-    def relationship(self) -> Relationship:
-        return Relationship(self.resolver.from_class, self.resolver.to_class)
-
-
-@dataclass(frozen=True, slots=True)
-class Relationship(object):
-    from_class: Type
-    to_class: Type
-
 
 def _resolve_ce_term(ce, t):
     t.conducting_equipment = ce

--- a/src/zepben/evolve/services/common/reference_resolvers.py
+++ b/src/zepben/evolve/services/common/reference_resolvers.py
@@ -110,21 +110,20 @@ class BoundReferenceResolver(object):
         return hash((type(self), self.from_obj, self.resolver, self.reverse_resolver))
 
 
-# @dataclass(frozen=True, eq=False, slots=True)
 @dataclass(frozen=True, eq=False, slots=True)
 class UnresolvedReference(object):
-    from_mrid: str
+    from_ref: IdentifiedObject
     to_mrid: str
     resolver: ReferenceResolver
 
     def __eq__(self, other: UnresolvedReference):
-        return self.from_mrid == other.from_mrid and self.to_mrid == other.to_mrid and self.resolver == other.resolver
+        return self.from_ref.mrid == other.from_ref.mrid and self.to_mrid == other.to_mrid and self.resolver == other.resolver
 
     def __ne__(self, other: UnresolvedReference):
-        return self.from_mrid != other.from_mrid or self.to_mrid != other.to_mrid or self.resolver != other.resolver
+        return self.from_ref.mrid != other.from_ref.mrid or self.to_mrid != other.to_mrid or self.resolver != other.resolver
 
     def __hash__(self):
-        return hash((type(self), self.from_mrid, self.to_mrid, self.resolver))
+        return hash((type(self), self.from_ref.mrid, self.to_mrid, self.resolver))
 
     @property
     def relationship(self) -> Relationship:

--- a/src/zepben/evolve/services/network/translator/__init__.py
+++ b/src/zepben/evolve/services/network/translator/__init__.py
@@ -252,7 +252,7 @@ Feeder.normal_energizing_substation_mrid = lambda self: getattr(self, "normalEne
 AcLineSegment.per_length_sequence_impedance_mrid = lambda self: getattr(self, "perLengthSequenceImpedanceMRID", None)
 
 # asset_info_mrid
-Conductor.asset_info_mrid = lambda self: getattr(self, "assetInfoMRID", None)
+Conductor.asset_info_mrid = lambda self: self.ce.eq.psr.assetInfoMRID
 AcLineSegment.asset_info_mrid = lambda self: self.cd.asset_info_mrid()
 PowerTransformer.asset_info_mrid = lambda self: self.ce.eq.psr.assetInfoMRID
 

--- a/src/zepben/evolve/services/network/translator/network_cim2proto.py
+++ b/src/zepben/evolve/services/network/translator/network_cim2proto.py
@@ -259,8 +259,7 @@ def usagepoint_to_pb(cim: UsagePoint) -> PBUsagePoint:
 
 # IEC61968 OPERATIONS #
 def operationalrestriction_to_pb(cim: OperationalRestriction) -> PBOperationalRestriction:
-    return PBOperationalRestriction(doc=document_to_pb(cim),
-                                    equipmentMRIDs=[str(io.mrid) for io in cim.equipment])
+    return PBOperationalRestriction(doc=document_to_pb(cim))
 
 
 # IEC61970 AUXILIARY EQUIPMENT #
@@ -290,7 +289,7 @@ def conductingequipment_to_pb(cim: ConductingEquipment) -> PBConductingEquipment
 
 
 def connectivitynode_to_pb(cim: ConnectivityNode) -> PBConnectivityNode:
-    return PBConnectivityNode(io=identifiedobject_to_pb(cim), terminalMRIDs=[str(io.mrid) for io in cim.terminals])
+    return PBConnectivityNode(io=identifiedobject_to_pb(cim))
 
 
 def connectivitynodecontainer_to_pb(cim: ConnectivityNodeContainer) -> PBConnectivityNodeContainer:
@@ -309,15 +308,13 @@ def equipment_to_pb(cim: Equipment) -> PBEquipment:
 
 
 def equipmentcontainer_to_pb(cim: EquipmentContainer) -> PBEquipmentContainer:
-    return PBEquipmentContainer(cnc=connectivitynodecontainer_to_pb(cim),
-                                equipmentMRIDs=[str(io.mrid) for io in cim.equipment])
+    return PBEquipmentContainer(cnc=connectivitynodecontainer_to_pb(cim))
 
 
 def feeder_to_pb(cim: Feeder) -> PBFeeder:
     return PBFeeder(ec=equipmentcontainer_to_pb(cim),
                     normalHeadTerminalMRID=mrid_or_empty(cim.normal_head_terminal),
-                    normalEnergizingSubstationMRID=mrid_or_empty(cim.normal_energizing_substation),
-                    currentEquipmentMRIDs=[str(io.mrid) for io in cim.current_equipment])
+                    normalEnergizingSubstationMRID=mrid_or_empty(cim.normal_energizing_substation))
 
 
 def geographicalregion_to_pb(cim: GeographicalRegion) -> PBGeographicalRegion:

--- a/src/zepben/evolve/streaming/get/consumer.py
+++ b/src/zepben/evolve/streaming/get/consumer.py
@@ -25,8 +25,8 @@ __all__ = ["CimConsumerClient", "MultiObjectResult", "extract_identified_object"
 
 @dataclass()
 class MultiObjectResult(object):
-    value: Dict[str, IdentifiedObject]
-    failed: Set[str]
+    value: Dict[str, IdentifiedObject] = dict()
+    failed: Set[str] = set()
 
 
 class CimConsumerClient(GrpcClient):

--- a/src/zepben/evolve/streaming/get/consumer.py
+++ b/src/zepben/evolve/streaming/get/consumer.py
@@ -14,7 +14,6 @@ from typing import Iterable, Dict, Optional, Set, Tuple
 
 from dataclassy import dataclass
 
-
 from zepben.evolve.streaming.exceptions import UnsupportedOperationException
 from zepben.protobuf.nc.nc_data_pb2 import NetworkIdentifiedObject
 
@@ -80,5 +79,3 @@ def extract_identified_object(service: NetworkService, nio: NetworkIdentifiedObj
         return service.add_from_pb(pbio), pbio.mrid()
     else:
         raise UnsupportedOperationException(f"Received a NetworkIdentifiedObject where no field was set")
-
-

--- a/src/zepben/evolve/streaming/get/network_consumer.py
+++ b/src/zepben/evolve/streaming/get/network_consumer.py
@@ -10,52 +10,25 @@ from typing import Iterable, Dict, Optional, AsyncGenerator, Union, List, Callab
 
 from dataclassy import dataclass
 
-from zepben.evolve import NetworkService, Feeder, ConnectivityNode, Terminal, Equipment, EquipmentContainer, Substation, IdentifiedObject
-from zepben.evolve.services.common.reference_resolvers import Relationship
+from zepben.evolve import NetworkService, Feeder
 from zepben.evolve.streaming.get.consumer import MultiObjectResult, extract_identified_object, CimConsumerClient
 from zepben.evolve.streaming.get.hierarchy.data import NetworkHierarchyIdentifiedObject, NetworkHierarchyGeographicalRegion, \
     NetworkHierarchySubGeographicalRegion, NetworkHierarchySubstation, NetworkHierarchy, NetworkHierarchyFeeder
 from zepben.evolve.streaming.grpc.grpc import GrpcResult
 from zepben.protobuf.nc.nc_pb2_grpc import NetworkConsumerStub
 import zepben.evolve.services.common.resolver as resolver
-from zepben.protobuf.nc.nc_requests_pb2 import GetIdentifiedObjectsRequest, GetNetworkHierarchyRequest, GetEquipmentForContainerRequest
+from zepben.protobuf.nc.nc_requests_pb2 import GetIdentifiedObjectsRequest, GetNetworkHierarchyRequest, GetEquipmentForContainerRequest, \
+    GetCurrentEquipmentForFeederRequest, GetEquipmentForRestrictionRequest, GetTerminalsForNodeRequest
 
 __all__ = ["NetworkConsumerClient", "SyncNetworkConsumerClient"]
 
 MAX_64_BIT_INTEGER = 9223372036854775807
-_EXCLUDED_GET_FEEDER = {
-    Relationship(ConnectivityNode, Terminal),
-    Relationship(Feeder, Equipment),
-    Relationship(Equipment, Feeder),
-    Relationship(EquipmentContainer, Equipment),
-    Relationship(Equipment, EquipmentContainer),
-    Relationship(Substation, Equipment),
-    Relationship(Equipment, Substation),
-}
 
 
 @dataclass(slots=True)
 class NetworkResult(object):
     network_service: Optional[NetworkService]
     failed: Set[str] = set()
-
-
-def _lookup(mrids: Iterable[str], lookup: Dict[str, NetworkHierarchyIdentifiedObject]):
-    return {mrid: lookup[mrid] for mrid in mrids if mrid is not None}
-
-
-def _finalise_links(geographical_regions: Dict[str, NetworkHierarchyGeographicalRegion],
-                    sub_geographical_regions: Dict[str, NetworkHierarchySubGeographicalRegion],
-                    substations: Dict[str, NetworkHierarchySubstation]):
-    for gr in geographical_regions.values():
-        for sgr in gr.sub_geographical_regions.values():
-            sgr.geographical_region = gr
-    for sgr in sub_geographical_regions.values():
-        for subs in sgr.substations.values():
-            subs.sub_geographical_region = sgr
-    for subs in substations.values():
-        for feeder in subs.feeders.values():
-            feeder.substation = subs
 
 
 class NetworkConsumerClient(CimConsumerClient):
@@ -100,7 +73,7 @@ class NetworkConsumerClient(CimConsumerClient):
         - An `Exception` if an error occurred while retrieving or processing the objects, in which case, `GrpcResult.was_successful` will return false.
           Note the warning above in this case.
         """
-        return await self._get_identified_objects(service, mrids)
+        return await self._handle_multi_object_rpc(service, mrids, self._process_identified_objects)
 
     async def get_equipment_for_container(self, service: NetworkService, mrid: str) -> GrpcResult[MultiObjectResult]:
         """
@@ -113,7 +86,50 @@ class NetworkConsumerClient(CimConsumerClient):
           If an item couldn't be added to `service` its mRID will be present in `MultiObjectResult.failed` (see `zepben.evolve.common.base_service.BaseService.add`).
         - An `Exception` if an error occurred while retrieving or processing the objects, in which case, `GrpcResult.was_successful` will return false.
         """
-        return await self._get_equipment_for_container(service, mrid)
+        return await self._handle_multi_object_rpc(service, mrid, self._process_equipment_container)
+
+    async def get_current_equipment_for_feeder(self, service: NetworkService, mrid: str) -> GrpcResult[MultiObjectResult]:
+        """
+        Retrieve the current `Equipment` for the `Feeder` represented by `mrid`. The current equipment is the equipment connected to the Feeder based on
+        the current phasing and switching of the network.
+
+        Exceptions that occur during retrieval will be caught and passed to all error handlers that have been registered against this client.
+
+        `mrid` The mRID of the `Feeder` to fetch current equipment for.
+        Returns a `GrpcResult` with a result of one of the following:
+        - A `MultiObjectResult` containing a map of the retrieved objects keyed by mRID. If an item is not found it will be excluded from the map.
+          If an item couldn't be added to `service` its mRID will be present in `MultiObjectResult.failed` (see `zepben.evolve.common.base_service.BaseService.add`).
+        - An `Exception` if an error occurred while retrieving or processing the objects, in which case, `GrpcResult.was_successful` will return false.
+        """
+        return await self._handle_multi_object_rpc(service, mrid, self._process_feeder)
+
+    async def get_equipment_for_restriction(self, service: NetworkService, mrid: str) -> GrpcResult[MultiObjectResult]:
+        """
+        Retrieve the `Equipment` for the `OperationalRestriction` represented by `mrid`.
+
+        Exceptions that occur during retrieval will be caught and passed to all error handlers that have been registered against this client.
+
+        `mrid` The mRID of the `OperationalRestriction` to fetch equipment for.
+        Returns a `GrpcResult` with a result of one of the following:
+        - A `MultiObjectResult` containing a map of the retrieved objects keyed by mRID. If an item is not found it will be excluded from the map.
+          If an item couldn't be added to `service` its mRID will be present in `MultiObjectResult.failed` (see `zepben.evolve.common.base_service.BaseService.add`).
+        - An `Exception` if an error occurred while retrieving or processing the objects, in which case, `GrpcResult.was_successful` will return false.
+        """
+        return await self._handle_multi_object_rpc(service, mrid, self._process_restriction)
+
+    async def get_terminals_for_connectivitynode(self, service: NetworkService, mrid: str) -> GrpcResult[MultiObjectResult]:
+        """
+        Retrieve the `Terminal`s for the `ConnectivityNode` represented by `mrid`.
+
+        Exceptions that occur during retrieval will be caught and passed to all error handlers that have been registered against this client.
+
+        `mrid` The mRID of the `ConnectivityNode` to fetch terminals for.
+        Returns a `GrpcResult` with a result of one of the following:
+        - A `MultiObjectResult` containing a map of the retrieved objects keyed by mRID. If an item is not found it will be excluded from the map.
+          If an item couldn't be added to `service` its mRID will be present in `MultiObjectResult.failed` (see `zepben.evolve.common.base_service.BaseService.add`).
+        - An `Exception` if an error occurred while retrieving or processing the objects, in which case, `GrpcResult.was_successful` will return false.
+        """
+        return await self._handle_multi_object_rpc(service, mrid, self._process_connectivitynode)
 
     async def get_network_hierarchy(self) -> GrpcResult[NetworkHierarchy]:
         """
@@ -152,46 +168,6 @@ class NetworkConsumerClient(CimConsumerClient):
 
         return await self.try_rpc(y)
 
-    async def _get_identified_objects(self, service: NetworkService, mrids: Iterable[str], result: MultiObjectResult = None) -> GrpcResult[MultiObjectResult]:
-        """
-        `service` The service to add any results to.
-        `mrids` The mRIDs to fetch from the server.
-        `result` an existing `MultiObjectResult` to populate. A new result will be created if not provided.
-        Returns a GrpcResult with a MultiObjectResult containing everything that was added to `service`.
-        """
-        if result is None:
-            result = MultiObjectResult()
-
-        async def y():
-            async for io, mrid in self._process_identified_objects(service, mrids):
-                if io:
-                    result.value[io.mrid] = io
-                else:
-                    result.failed.add(mrid)
-            return result
-
-        return await self.try_rpc(y)
-
-    async def _get_equipment_for_container(self, service: NetworkService, mrid: str, result: MultiObjectResult = None) -> GrpcResult[MultiObjectResult]:
-        """
-        `service` The service to add any results to.
-        `mrid` The mRID of the `EquipmentContainer` to fetch `Equipment` for from the server.
-        `result` an existing `MultiObjectResult` to populate. A new result will be created if not provided.
-        Returns a GrpcResult with a MultiObjectResult containing everything that was added to `service`.
-        """
-        if result is None:
-            result = MultiObjectResult()
-
-        async def y():
-            async for io, _mrid in self._process_equipment_container(service, mrid):
-                if io:
-                    result.value[io.mrid] = io
-                else:
-                    result.failed.add(_mrid)
-            return result
-
-        return await self.try_rpc(y)
-
     async def _get_network_hierarchy(self) -> GrpcResult[NetworkHierarchy]:
         return await self.try_rpc(self._handle_network_hierarchy)
 
@@ -206,22 +182,22 @@ class NetworkConsumerClient(CimConsumerClient):
             return GrpcResult(result=ValueError(f"Requested mrid {mrid} was not a Feeder, was {type(feeder)}"))
 
         mor = MultiObjectResult()
-        res = (await self._get_equipment_for_container(service, feeder.mrid)).throw_on_error()
+        res = (await self._handle_multi_object_rpc(service, feeder.mrid, self._process_equipment_container)).throw_on_error()
         mor.value.update(res.result.value)
         # We need to resolve all the unresolved references for each piece of equipment, but then we need to
         # also do the same for the resolutions, and so on so forth until the entire tree of references originating from the Feeder has been resolved,
         # however we don't know how long this tree is until we've resolved everything. So we start by resolving all the equipment, then we iteratively
         # descend the tree by checking for unresolved references for the objects we just resolved in the previous iteration.
-        to_resolve = self._get_unresolved_mrids(service, res.result.value.keys(), _EXCLUDED_GET_FEEDER)
+        to_resolve = _get_unresolved_mrids(service, res.result.value.keys())
         while True:
             res = await self._get_objects(service, to_resolve)
             if not res.value:
                 break
             mor.value.update(res.value)
-            to_resolve = self._get_unresolved_mrids(service, res.value.keys(), _EXCLUDED_GET_FEEDER)
+            to_resolve = _get_unresolved_mrids(service, res.value.keys())
 
         # Get the rest of the unresolved references for the feeder (e.g substation)
-        await self._get_objects(service, service.get_unresolved_reference_mrids_from(feeder.mrid), mor)
+        await self._get_objects(service, [x.to_mrid for x in service.get_unresolved_references_from(feeder.mrid)], mor)
         mor.value[feeder.mrid] = feeder
 
         return GrpcResult(result=mor)
@@ -229,17 +205,8 @@ class NetworkConsumerClient(CimConsumerClient):
     async def _get_objects(self, service: NetworkService, mrids: Iterable[str], result: MultiObjectResult = None) -> MultiObjectResult:
         if not mrids:
             return MultiObjectResult() if result is None else result
-        objects = (await self._get_identified_objects(service, mrids, result)).throw_on_error()
+        objects = (await self._handle_multi_object_rpc(service, mrids, self._process_identified_objects, result)).throw_on_error()
         return objects.result
-
-    def _get_unresolved_mrids(self, service: NetworkService, mrids: Iterable[str], excluded: Set[Relationship] = None) -> Generator[str, None, None]:
-        seen = set()
-        for m in mrids:
-            for i in service.get_unresolved_reference_mrids_from(m, excluded):
-                if i in seen:
-                    continue
-                yield i
-                seen.add(i)
 
     async def _retrieve_network(self) -> GrpcResult[Union[NetworkResult, Exception]]:
         service = NetworkService()
@@ -276,14 +243,25 @@ class NetworkConsumerClient(CimConsumerClient):
 
         return GrpcResult(NetworkResult(service, mor.failed))
 
-    async def _process_unresolved(self, service):
-        for mrid in service.unresolved_mrids():
-            await self._get_identified_object(service, mrid)
-
     async def _process_equipment_container(self, service: NetworkService, mrid: str) -> AsyncGenerator[IdentifiedObject, None]:
         responses = self._stub.getEquipmentForContainer(GetEquipmentForContainerRequest(mrid=mrid))
         for response in responses:
             yield extract_identified_object(service, response.identifiedObject)
+
+    async def _process_feeder(self, service: NetworkService, mrid: str) -> AsyncGenerator[IdentifiedObject, None]:
+        responses = self._stub.getCurrentEquipmentForFeeder(GetCurrentEquipmentForFeederRequest(mrid=mrid))
+        for response in responses:
+            yield extract_identified_object(service, response.identifiedObject)
+
+    async def _process_restriction(self, service: NetworkService, mrid: str) -> AsyncGenerator[IdentifiedObject, None]:
+        responses = self._stub.getEquipmentForRestriction(GetEquipmentForRestrictionRequest(mrid=mrid))
+        for response in responses:
+            yield extract_identified_object(service, response.identifiedObject)
+
+    async def _process_connectivitynode(self, service: NetworkService, mrid: str) -> AsyncGenerator[IdentifiedObject, None]:
+        responses = self._stub.getTerminalsForNode(GetTerminalsForNodeRequest(mrid=mrid))
+        for response in responses:
+            yield service.add_from_pb(response.terminal), response.terminal.mrid()
 
     async def _process_identified_objects(self, service: NetworkService, mrids: Iterable[str]) -> AsyncGenerator[IdentifiedObject, None]:
         to_fetch = set()
@@ -297,10 +275,7 @@ class NetworkConsumerClient(CimConsumerClient):
 
         responses = self._stub.getIdentifiedObjects(GetIdentifiedObjectsRequest(mrids=to_fetch))
         for response in responses:
-            og = response.objectGroup
-            yield extract_identified_object(service, og.identifiedObject)
-            for owned_obj in og.ownedIdentifiedObject:
-                yield extract_identified_object(service, owned_obj)
+            yield extract_identified_object(service, response.identifiedObject)
 
     async def _handle_network_hierarchy(self):
         response = self._stub.getNetworkHierarchy(GetNetworkHierarchyRequest())
@@ -313,6 +288,28 @@ class NetworkConsumerClient(CimConsumerClient):
 
         _finalise_links(geographical_regions, sub_geographical_regions, substations)
         return NetworkHierarchy(geographical_regions, sub_geographical_regions, substations, feeders)
+
+    async def _handle_multi_object_rpc(self, service: NetworkService, mrid: Union[str, Iterable[str]], func: Callable[[NetworkService, Union[str, Iterable[str]]], AsyncGenerator[IdentifiedObject, None]],
+                                       result: MultiObjectResult = None) -> GrpcResult[MultiObjectResult]:
+        """
+        `service` The service to add any results to.
+        `mrid` The mRID of the `EquipmentContainer` to fetch `Equipment` for from the server.
+        `result` an existing `MultiObjectResult` to populate. A new result will be created if not provided.
+        Returns a GrpcResult with a MultiObjectResult containing everything that was added to `service`, and potentially a list of failed mRIDs that couldn't
+        be added.
+        """
+        if result is None:
+            result = MultiObjectResult()
+
+        async def y():
+            async for io, _mrid in func(service, mrid):
+                if io:
+                    result.value[io.mrid] = io
+                else:
+                    result.failed.add(_mrid)
+            return result
+
+        return await self.try_rpc(y)
 
 
 class SyncNetworkConsumerClient(NetworkConsumerClient):
@@ -371,3 +368,88 @@ class SyncNetworkConsumerClient(NetworkConsumerClient):
 
     def retrieve_network(self) -> GrpcResult[Union[NetworkResult, Exception]]:
         return get_event_loop().run_until_complete(super().retrieve_network())
+
+    def get_equipment_for_container(self, service: NetworkService, mrid: str) -> GrpcResult[MultiObjectResult]:
+        """
+        Retrieve the `Equipment` for the `EquipmentContainer` represented by `mrid`
+        Exceptions that occur during retrieval will be caught and passed to all error handlers that have been registered against this client.
+
+        `mrid` The mRID of the `EquipmentContainer` to fetch equipment for.
+        Returns a `GrpcResult` with a result of one of the following:
+        - A `MultiObjectResult` containing a map of the retrieved objects keyed by mRID. If an item is not found it will be excluded from the map.
+          If an item couldn't be added to `service` its mRID will be present in `MultiObjectResult.failed` (see `zepben.evolve.common.base_service.BaseService.add`).
+        - An `Exception` if an error occurred while retrieving or processing the objects, in which case, `GrpcResult.was_successful` will return false.
+        """
+        return get_event_loop().run_until_complete(super().get_equipment_for_container(service, mrid))
+
+    def get_current_equipment_for_feeder(self, service: NetworkService, mrid: str) -> GrpcResult[MultiObjectResult]:
+        """
+        Retrieve the current `Equipment` for the `Feeder` represented by `mrid`. The current equipment is the equipment connected to the Feeder based on
+        the current phasing and switching of the network.
+
+        Exceptions that occur during retrieval will be caught and passed to all error handlers that have been registered against this client.
+
+        `mrid` The mRID of the `Feeder` to fetch current equipment for.
+        Returns a `GrpcResult` with a result of one of the following:
+        - A `MultiObjectResult` containing a map of the retrieved objects keyed by mRID. If an item is not found it will be excluded from the map.
+          If an item couldn't be added to `service` its mRID will be present in `MultiObjectResult.failed` (see `zepben.evolve.common.base_service.BaseService.add`).
+        - An `Exception` if an error occurred while retrieving or processing the objects, in which case, `GrpcResult.was_successful` will return false.
+        """
+        return get_event_loop().run_until_complete(super().get_current_equipment_for_feeder(service, mrid))
+
+    def get_equipment_for_restriction(self, service: NetworkService, mrid: str) -> GrpcResult[MultiObjectResult]:
+        """
+        Retrieve the `Equipment` for the `OperationalRestriction` represented by `mrid`.
+
+        Exceptions that occur during retrieval will be caught and passed to all error handlers that have been registered against this client.
+
+        `mrid` The mRID of the `OperationalRestriction` to fetch equipment for.
+        Returns a `GrpcResult` with a result of one of the following:
+        - A `MultiObjectResult` containing a map of the retrieved objects keyed by mRID. If an item is not found it will be excluded from the map.
+          If an item couldn't be added to `service` its mRID will be present in `MultiObjectResult.failed` (see `zepben.evolve.common.base_service.BaseService.add`).
+        - An `Exception` if an error occurred while retrieving or processing the objects, in which case, `GrpcResult.was_successful` will return false.
+        """
+        return get_event_loop().run_until_complete(super().get_equipment_for_restriction(service, mrid))
+
+    def get_terminals_for_connectivitynode(self, service: NetworkService, mrid: str) -> GrpcResult[MultiObjectResult]:
+        """
+        Retrieve the `Terminal`s for the `ConnectivityNode` represented by `mrid`.
+
+        Exceptions that occur during retrieval will be caught and passed to all error handlers that have been registered against this client.
+
+        `mrid` The mRID of the `ConnectivityNode` to fetch terminals for.
+        Returns a `GrpcResult` with a result of one of the following:
+        - A `MultiObjectResult` containing a map of the retrieved objects keyed by mRID. If an item is not found it will be excluded from the map.
+          If an item couldn't be added to `service` its mRID will be present in `MultiObjectResult.failed` (see `zepben.evolve.common.base_service.BaseService.add`).
+        - An `Exception` if an error occurred while retrieving or processing the objects, in which case, `GrpcResult.was_successful` will return false.
+        """
+        return get_event_loop().run_until_complete(super().get_terminals_for_connectivitynode(service, mrid))
+
+
+def _lookup(mrids: Iterable[str], lookup: Dict[str, NetworkHierarchyIdentifiedObject]):
+    return {mrid: lookup[mrid] for mrid in mrids if mrid is not None}
+
+
+def _finalise_links(geographical_regions: Dict[str, NetworkHierarchyGeographicalRegion],
+                    sub_geographical_regions: Dict[str, NetworkHierarchySubGeographicalRegion],
+                    substations: Dict[str, NetworkHierarchySubstation]):
+    for gr in geographical_regions.values():
+        for sgr in gr.sub_geographical_regions.values():
+            sgr.geographical_region = gr
+    for sgr in sub_geographical_regions.values():
+        for subs in sgr.substations.values():
+            subs.sub_geographical_region = sgr
+    for subs in substations.values():
+        for feeder in subs.feeders.values():
+            feeder.substation = subs
+
+
+def _get_unresolved_mrids(service: NetworkService, mrids: Iterable[str]) -> Generator[str, None, None]:
+    seen = set()
+    for m in mrids:
+        for i in service.get_unresolved_references_from(m):
+            if i in seen:
+                continue
+            yield i.to_mrid
+            seen.add(i)
+

--- a/src/zepben/evolve/util.py
+++ b/src/zepben/evolve/util.py
@@ -122,6 +122,6 @@ class CopyableUUID(UUID):
         super().__init__(bytes=os.urandom(16), version=4)
 
     def copy(self):
-        return UUID(bytes=os.urandom(16), version=4)
+        return str(UUID(bytes=os.urandom(16), version=4))
 
 

--- a/src/zepben/evolve/util.py
+++ b/src/zepben/evolve/util.py
@@ -8,8 +8,10 @@ from __future__ import annotations
 import re
 import os
 from collections.abc import Sized
-from typing import Set, List, Optional, Iterable, Callable, Any, TypeVar, Generator
+from typing import List, Optional, Iterable, Callable, Any, TypeVar, Generator
 from uuid import UUID
+
+__all__ = ["get_by_mrid", "contains_mrid", "safe_remove", "nlen", "ngen", "is_none_or_empty", "require", "pb_or_none"]
 
 T = TypeVar('T')
 

--- a/test/network_fixtures.py
+++ b/test/network_fixtures.py
@@ -10,7 +10,7 @@ from pytest import fixture
 from zepben.evolve import NetworkService, Feeder, PhaseCode, EnergySource, EnergySourcePhase, Junction, ConductingEquipment, Breaker, PowerTransformer, \
     UsagePoint, Terminal, PowerTransformerEnd, WindingConnection, BaseVoltage, Meter, AssetOwner, CustomerService, Organisation, AcLineSegment, \
     PerLengthSequenceImpedance, WireInfo, EnergyConsumer, GeographicalRegion, SubGeographicalRegion, Substation, PowerSystemResource, Location, PositionPoint, \
-    SetPhases
+    SetPhases, OverheadWireInfo
 
 __all__ = ["create_terminals", "create_junction_for_connecting", "create_source_for_connecting", "create_switch_for_connecting", "create_acls_for_connecting",
            "create_energy_consumer_for_connecting", "create_feeder", "create_substation", "create_power_transformer_for_connecting", "create_terminals",
@@ -148,8 +148,8 @@ def create_acls_for_connecting(network: NetworkService, mrid: str = "", phases: 
 
     try:
         wi = network.get(wi_mrid, WireInfo)
-    except:
-        wi = WireInfo(wi_mrid)
+    except KeyError:
+        wi = OverheadWireInfo(wi_mrid)
         network.add(wi)
 
     acls = AcLineSegment(mrid, name=f"{mrid} name", per_length_sequence_impedance=plsi, asset_info=wi, length=length)

--- a/test/network_fixtures.py
+++ b/test/network_fixtures.py
@@ -232,6 +232,10 @@ def add_location(network: NetworkService, psr: PowerSystemResource, *coords: flo
 
 @fixture()
 async def feeder_network():
+    """
+                c1       c2
+    source-fcb------fsp------tx
+    """
     network_service = NetworkService()
 
     source = create_source_for_connecting(network_service, "source", 1, PhaseCode.AB)

--- a/test/pb_creators.py
+++ b/test/pb_creators.py
@@ -231,7 +231,7 @@ def usagepoint():
 
 # IEC61968 OPERATIONS #
 def operationalrestriction():
-    return builds(PBOperationalRestriction, doc=document(), equipmentMRIDs=lists(text(alphabet=ALPHANUM, max_size=TEXT_MAX_SIZE), max_size=2))
+    return builds(PBOperationalRestriction, doc=document())
 
 
 # IEC61970 AUXILIARY EQUIPMENT #
@@ -258,7 +258,7 @@ def conductingequipment():
 
 
 def connectivitynode():
-    return builds(PBConnectivityNode, io=identifiedobject(), terminalMRIDs=lists(text(alphabet=ALPHANUM, max_size=TEXT_MAX_SIZE), max_size=5))
+    return builds(PBConnectivityNode, io=identifiedobject())
 
 
 def connectivitynodecontainer():
@@ -274,13 +274,12 @@ def equipment():
 
 
 def equipmentcontainer():
-    return builds(PBEquipmentContainer, cnc=connectivitynodecontainer(), equipmentMRIDs=lists(text(alphabet=ALPHANUM, max_size=TEXT_MAX_SIZE), max_size=10))
+    return builds(PBEquipmentContainer, cnc=connectivitynodecontainer())
 
 
 def feeder():
     return builds(PBFeeder, ec=equipmentcontainer(), normalHeadTerminalMRID=text(alphabet=ALPHANUM, max_size=TEXT_MAX_SIZE),
-                  normalEnergizingSubstationMRID=text(alphabet=ALPHANUM, max_size=TEXT_MAX_SIZE),
-                  currentEquipmentMRIDs=lists(text(alphabet=ALPHANUM, max_size=TEXT_MAX_SIZE), max_size=2))
+                  normalEnergizingSubstationMRID=text(alphabet=ALPHANUM, max_size=TEXT_MAX_SIZE))
 
 
 def geographicalregion():

--- a/test/run_streaming.py
+++ b/test/run_streaming.py
@@ -15,9 +15,9 @@ def run_retrieve():
         client = SyncNetworkConsumerClient(channel=channel)
         result = client.retrieve_network()
         result.throw_on_error()
-        network = result.result.network_service
-        print(len(network._unresolved_references))
-        print(network.len_of())
+        service = result.result.network_service
+        print(f"Num unresolved: {service.num_unresolved_references()}")
+        print(f"Num objects: {service.len_of()}")
 
 
 def run_feeder():
@@ -26,10 +26,14 @@ def run_feeder():
         client = SyncNetworkConsumerClient(channel=channel)
         result = client.get_feeder(service, "PBH3A")
         network = result.result
-        print(len(service._unresolved_references))
-        print(service.len_of())
+        print(f"Num unresolved: {service.num_unresolved_references()}")
+        print(f"Num objects: {service.len_of()}")
 
 
 if __name__ == "__main__":
-    cProfile.run("run_retrieve()")
+    print("running get feeder")
     # cProfile.run("run_feeder()")
+    run_feeder()
+    print("running retrieve network")
+    # cProfile.run("run_retrieve()")
+    run_retrieve()

--- a/test/services/common/__init__.py
+++ b/test/services/common/__init__.py
@@ -3,3 +3,4 @@
 #  This Source Code Form is subject to the terms of the Mozilla Public
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+

--- a/test/services/common/test_base_service.py
+++ b/test/services/common/test_base_service.py
@@ -1,0 +1,121 @@
+#  Copyright 2021 Zeppelin Bend Pty Ltd
+#
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from typing import List, Union
+
+from pytest import fixture
+from zepben.evolve import BaseService, Terminal, resolver, UnresolvedReference, Junction, BaseVoltage, Location, AcLineSegment, CableInfo, \
+    PerLengthSequenceImpedance, IdentifiedObject, ConnectivityNode, Feeder
+
+
+@fixture
+def service():
+    service = BaseService("base_service")
+    yield service
+
+
+def test_unresolved_bidirectional_references(service: BaseService):
+    term = Terminal("t1")
+    assert service.add(term)
+    assert service.resolve_or_defer_reference(resolver.conducting_equipment(term), "j1") is False
+
+    assert list(service.unresolved_references())[0] == UnresolvedReference(term.mrid, "j1", resolver.conducting_equipment(term).resolver)
+    assert "j1" in service.get_unresolved_reference_mrids_by_resolver(resolver.conducting_equipment(term))
+
+    j1 = Junction("j1")
+    assert service.resolve_or_defer_reference(resolver.ce_terminals(j1), term.mrid)
+    assert not list(service.unresolved_references())  # no unresolved refs now
+    assert not list(service.get_unresolved_reference_mrids_by_resolver(resolver.conducting_equipment(term)))
+    assert not list(service.get_unresolved_reference_mrids_by_resolver(resolver.ce_terminals(j1)))
+    assert not service.has_unresolved_references()
+
+    assert term.conducting_equipment is j1
+    assert j1.get_terminal_by_mrid(term.mrid) is term
+    assert service.add(j1)
+
+
+def test_unresolved_unidirectional_references(service: BaseService):
+    j1 = Junction("j1")
+    assert service.add(j1)
+    assert service.resolve_or_defer_reference(resolver.ce_base_voltage(j1), "bv1") is False
+    assert list(service.unresolved_references())[0] == UnresolvedReference(j1.mrid, "bv1", resolver.ce_base_voltage(j1).resolver)
+    assert "bv1" in service.get_unresolved_reference_mrids_by_resolver(resolver.ce_base_voltage(j1))
+
+    bv1 = BaseVoltage("bv1")
+    assert service.add(bv1)
+    assert not service.has_unresolved_references()
+    assert not list(service.get_unresolved_reference_mrids_by_resolver(resolver.ce_base_voltage(j1)))
+
+    assert j1.base_voltage is bv1
+
+
+def test_mrid_must_be_unique(service):
+    j1 = Junction("id1")
+    assert service.add(j1)
+
+    loc = Location(j1.mrid)
+    assert not service.add(loc)
+
+
+def test_unresolved_references(service: BaseService):
+    f = Feeder("f")
+    acls1 = AcLineSegment("acls1")
+    acls2 = AcLineSegment("acls2")
+    plsi1 = PerLengthSequenceImpedance("plsi1")
+    service.resolve_or_defer_reference(resolver.per_length_sequence_impedance(acls1), "plsi1")
+    t1 = Terminal("t1")
+    t2 = Terminal("t2")
+    service.resolve_or_defer_reference(resolver.ce_terminals(acls1), "t1")
+    service.resolve_or_defer_reference(resolver.ce_terminals(acls1), "t2")
+    ci1 = CableInfo("ci1")
+    service.resolve_or_defer_reference(resolver.asset_info(acls1), "ci1")
+    service.resolve_or_defer_reference(resolver.containers(acls1), "f")
+    service.resolve_or_defer_reference(resolver.containers(acls2), "f")
+
+    assert service.add(acls1)
+    assert service.add(acls2)
+    assert service.num_unresolved_references() == 6
+    refs_for_acls1 = list(service.get_unresolved_reference_mrids_from("acls1"))
+    for expected in (plsi1.mrid, t1.mrid, t2.mrid, ci1.mrid):
+        assert expected in refs_for_acls1
+
+    refs = list(service.get_unresolved_reference_mrids_by_resolver(resolver.per_length_sequence_impedance(acls1)))
+    assert plsi1.mrid in refs
+
+    check_unresolved_reference(t1.mrid, acls1.mrid, service.get_unresolved_reference_mrids_to)
+    check_unresolved_reference(t2.mrid, acls1.mrid, service.get_unresolved_reference_mrids_to)
+    check_unresolved_reference(plsi1.mrid, acls1.mrid, service.get_unresolved_reference_mrids_to)
+    check_unresolved_reference(ci1.mrid, acls1.mrid, service.get_unresolved_reference_mrids_to)
+
+    add_and_check(service, f, [acls1, acls2], "equipment_containers")
+    assert service.num_unresolved_references() == 4
+    add_and_check(service, plsi1, acls1, "per_length_sequence_impedance")
+    assert service.num_unresolved_references() == 3
+    add_and_check(service, ci1, acls1, "wire_info")
+    assert service.num_unresolved_references() == 2
+    add_and_check(service, t1, acls1, "terminals")
+    assert service.num_unresolved_references() == 1
+    add_and_check(service, t2, acls1, "terminals")
+    assert service.num_unresolved_references() == 0
+
+
+def add_and_check(service: BaseService, to_add, to_check: Union[IdentifiedObject, List[IdentifiedObject]], to_check_reference):
+    service.add(to_add)
+    if isinstance(to_check, IdentifiedObject):
+        to_check = [to_check]
+    for io in to_check:
+        refs = list(service.get_unresolved_reference_mrids_from(io.mrid))
+        assert to_add.mrid not in refs
+        assert to_add.mrid not in service.get_unresolved_reference_mrids_to(to_add.mrid)
+        attr = getattr(io, to_check_reference)
+        if isinstance(attr, IdentifiedObject):
+            assert attr is to_add
+        else:  # Assume an iterable/generator property (e.g terminals)
+            assert to_add in attr
+
+
+def check_unresolved_reference(to_check, expected_from, getter):
+    refs = list(getter(to_check))
+    assert expected_from in refs

--- a/test/services/common/test_base_service.py
+++ b/test/services/common/test_base_service.py
@@ -7,7 +7,7 @@ from typing import List, Union
 
 from pytest import fixture
 from zepben.evolve import BaseService, Terminal, resolver, UnresolvedReference, Junction, BaseVoltage, Location, AcLineSegment, CableInfo, \
-    PerLengthSequenceImpedance, IdentifiedObject, ConnectivityNode, Feeder
+    PerLengthSequenceImpedance, IdentifiedObject, ConnectivityNode, Feeder, OperationalRestriction, NetworkService
 
 
 @fixture
@@ -99,6 +99,19 @@ def test_unresolved_references(service: BaseService):
     assert service.num_unresolved_references() == 1
     add_and_check(service, t2, acls1, "terminals")
     assert service.num_unresolved_references() == 0
+
+
+def test_add_resolves_reverse_relationship():
+    or1 = OperationalRestriction("or1")
+    eq1 = AcLineSegment("eq1", operational_restrictions=[or1])
+    or1.add_equipment(eq1)
+
+    ns = NetworkService("test")
+    ns.add_from_pb(eq1.to_pb())
+    ns.add_from_pb(or1.to_pb())
+
+    assert ns.get("eq1") in ns.get("or1").equipment
+    assert ns.get("or1") in ns.get("eq1").operational_restrictions
 
 
 def add_and_check(service: BaseService, to_add, to_check: Union[IdentifiedObject, List[IdentifiedObject]], to_check_reference):

--- a/test/services/common/test_reference_resolver.py
+++ b/test/services/common/test_reference_resolver.py
@@ -1,0 +1,81 @@
+#  Copyright 2021 Zeppelin Bend Pty Ltd
+#
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from zepben.evolve import UnresolvedReference, Terminal, resolver, BoundReferenceResolver, AcLineSegment, ReferenceResolver, ConductingEquipment
+from zepben.evolve.services.common.reference_resolvers import term_to_ce_resolver, term_to_cn_resolver
+
+
+def test_unresolved_reference_equality():
+    t1 = Terminal("t1")
+    ur1 = UnresolvedReference(from_mrid=t1.mrid, to_mrid="j1", resolver=resolver.conducting_equipment(t1))
+    ur2 = UnresolvedReference(from_mrid=t1.mrid, to_mrid="j1", resolver=resolver.conducting_equipment(t1))
+    assert ur1 == ur2
+    assert not ur1 != ur2
+
+    t2 = Terminal("t2")
+    ur3 = UnresolvedReference(from_mrid=t2.mrid, to_mrid="j1", resolver=resolver.conducting_equipment(t1))
+    assert ur1 != ur3
+    assert not ur1 == ur3
+
+    ur4 = UnresolvedReference(from_mrid=t1.mrid, to_mrid="j1", resolver=resolver.conducting_equipment(t2))
+    assert ur1 != ur4
+    assert ur3 != ur4
+
+    ur5 = UnresolvedReference(from_mrid=t1.mrid, to_mrid="j2", resolver=resolver.conducting_equipment(t1))
+    assert ur1 != ur5
+
+
+def test_bound_reference_equality():
+    t1 = Terminal("t1")
+    br1 = BoundReferenceResolver(from_obj=t1, resolver=resolver.conducting_equipment(t1), reverse_resolver=None)
+    br2 = BoundReferenceResolver(from_obj=t1, resolver=resolver.conducting_equipment(t1), reverse_resolver=None)
+    assert br1 == br2
+    assert not br1 != br2
+
+    t2 = Terminal("t1")
+    br3 = BoundReferenceResolver(from_obj=t2, resolver=resolver.conducting_equipment(t1), reverse_resolver=None)
+    assert br1 != br3
+    assert not br1 == br3
+
+    br4 = BoundReferenceResolver(from_obj=t1, resolver=resolver.conducting_equipment(t2), reverse_resolver=None)
+    assert br1 != br4
+    assert br3 != br4
+
+    ce1 = AcLineSegment("acls1")
+    br5 = BoundReferenceResolver(from_obj=t1, resolver=resolver.conducting_equipment(t1), reverse_resolver=resolver.ce_terminals(ce1))
+    br6 = BoundReferenceResolver(from_obj=t1, resolver=resolver.conducting_equipment(t1), reverse_resolver=resolver.ce_terminals(ce1))
+    assert br5 == br6
+    assert br5 != br1
+
+    ce2 = AcLineSegment("acls1")
+    br7 = BoundReferenceResolver(from_obj=t1, resolver=resolver.conducting_equipment(t1), reverse_resolver=resolver.ce_terminals(ce2))
+    assert br5 != br7
+
+    br8 = BoundReferenceResolver(from_obj=t1, resolver=resolver.conducting_equipment(t1), reverse_resolver=None)
+    assert br7 != br8
+    assert br8 != br7
+
+
+def test_reference_resolver_equality():
+    ur1 = ReferenceResolver(from_class=Terminal, to_class=Terminal, resolve=term_to_ce_resolver)
+    ur2 = ReferenceResolver(from_class=Terminal, to_class=Terminal, resolve=term_to_ce_resolver)
+    assert ur1 == ur2
+    assert not ur1 != ur2
+
+    ur3 = ReferenceResolver(from_class=Terminal, to_class=Terminal, resolve=term_to_cn_resolver)
+    assert ur1 != ur3
+    assert not ur1 == ur3
+
+    ur4 = ReferenceResolver(from_class=Terminal, to_class=ConductingEquipment, resolve=term_to_cn_resolver)
+    assert ur1 != ur4
+    assert ur3 != ur4
+
+    ur5 = ReferenceResolver(from_class=Terminal, to_class=ConductingEquipment, resolve=term_to_ce_resolver)
+    assert ur1 != ur5
+    assert not ur1 == ur5
+
+    ur6 = ReferenceResolver(from_class=ConductingEquipment, to_class=Terminal, resolve=term_to_ce_resolver)
+    assert ur1 != ur6
+    assert not ur1 == ur6

--- a/test/services/common/test_reference_resolver.py
+++ b/test/services/common/test_reference_resolver.py
@@ -9,21 +9,21 @@ from zepben.evolve.services.common.reference_resolvers import term_to_ce_resolve
 
 def test_unresolved_reference_equality():
     t1 = Terminal("t1")
-    ur1 = UnresolvedReference(from_mrid=t1.mrid, to_mrid="j1", resolver=resolver.conducting_equipment(t1))
-    ur2 = UnresolvedReference(from_mrid=t1.mrid, to_mrid="j1", resolver=resolver.conducting_equipment(t1))
+    ur1 = UnresolvedReference(from_ref=t1, to_mrid="j1", resolver=resolver.conducting_equipment(t1))
+    ur2 = UnresolvedReference(from_ref=t1, to_mrid="j1", resolver=resolver.conducting_equipment(t1))
     assert ur1 == ur2
     assert not ur1 != ur2
 
     t2 = Terminal("t2")
-    ur3 = UnresolvedReference(from_mrid=t2.mrid, to_mrid="j1", resolver=resolver.conducting_equipment(t1))
+    ur3 = UnresolvedReference(from_ref=t2, to_mrid="j1", resolver=resolver.conducting_equipment(t1))
     assert ur1 != ur3
     assert not ur1 == ur3
 
-    ur4 = UnresolvedReference(from_mrid=t1.mrid, to_mrid="j1", resolver=resolver.conducting_equipment(t2))
+    ur4 = UnresolvedReference(from_ref=t1, to_mrid="j1", resolver=resolver.conducting_equipment(t2))
     assert ur1 != ur4
     assert ur3 != ur4
 
-    ur5 = UnresolvedReference(from_mrid=t1.mrid, to_mrid="j2", resolver=resolver.conducting_equipment(t1))
+    ur5 = UnresolvedReference(from_ref=t1, to_mrid="j2", resolver=resolver.conducting_equipment(t1))
     assert ur1 != ur5
 
 

--- a/test/test_consumer.py
+++ b/test/test_consumer.py
@@ -3,15 +3,22 @@
 #  This Source Code Form is subject to the terms of the Mozilla Public
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from typing import List
+
 import pytest
 from hypothesis import given, settings, Phase
 from zepben.protobuf.nc.nc_data_pb2 import NetworkIdentifiedObject, IdentifiedObjectGroup
+from zepben.protobuf.nc.nc_requests_pb2 import GetIdentifiedObjectsRequest
 from zepben.protobuf.nc.nc_responses_pb2 import GetIdentifiedObjectsResponse
 from unittest.mock import MagicMock
 
 from test.pb_creators import networkidentifiedobjects, aclinesegment
-from zepben.evolve import NetworkConsumerClient, NetworkService
+from zepben.evolve import NetworkConsumerClient, NetworkService, IdentifiedObject, CableInfo, ConductingEquipment, AcLineSegment, Breaker, EnergySource, \
+    EnergySourcePhase, Junction, PowerTransformer, PowerTransformerEnd, ConnectivityNode, Feeder, Location, OverheadWireInfo, PerLengthSequenceImpedance, \
+    Substation, Terminal
 
+
+# TODO: Test behaviour of "failures" with get_feeder/get_identified_objects
 
 class TestConsumer(object):
 
@@ -54,7 +61,6 @@ class TestConsumer(object):
         assert result.was_successful
         assert result.result is None
 
-
     @pytest.mark.asyncio
     async def test_get_network_hierarchy(self, feeder_network):
         pass
@@ -62,3 +68,76 @@ class TestConsumer(object):
     @pytest.mark.asyncio
     async def test_retrieve_network(self):
         pass
+
+    @pytest.mark.asyncio
+    async def test_get_feeder(self, feeder_network):
+        ns = NetworkService()
+        feeder_mrid = "f001"
+
+        def create_feeder_responses(request: GetIdentifiedObjectsRequest, *args, **kwargs):
+            objects = []
+            for mrid in request.mrids:
+                io = feeder_network.get(mrid)
+                if io:
+                    objects.append(io)
+            return response_of(objects)
+
+        stub = MagicMock(**{"getIdentifiedObjects.side_effect": create_feeder_responses})
+        client = NetworkConsumerClient(stub=stub)
+        objects = await client.get_feeder(ns, feeder_mrid)
+        assert len(objects.result.value) == ns.len_of() == feeder_network.len_of()
+        assert objects.was_successful
+        assert feeder_mrid in objects.result.value
+        for io in objects.result.value.values():
+            assert ns.get(io.mrid) == io
+
+        for io in ns.objects():
+            assert objects.result.value[io.mrid] == io
+        assert len(objects.result.failed) == 0
+
+
+def response_of(objects: List[IdentifiedObject]):
+    responses = []
+    for obj in objects:
+        og = IdentifiedObjectGroup()
+        if isinstance(obj, CableInfo):
+            nio = NetworkIdentifiedObject(cableInfo=obj.to_pb())
+        elif isinstance(obj, ConductingEquipment):
+            # og.ownedIdentifiedObject.extend([NetworkIdentifiedObject(terminal=t.to_pb()) for t in obj.terminals])
+            if isinstance(obj, AcLineSegment):
+                nio = NetworkIdentifiedObject(acLineSegment=obj.to_pb())
+            elif isinstance(obj, Breaker):
+                nio = NetworkIdentifiedObject(breaker=obj.to_pb())
+            elif isinstance(obj, EnergySource):
+                nio = NetworkIdentifiedObject(energySource=obj.to_pb())
+            elif isinstance(obj, EnergySourcePhase):
+                nio = NetworkIdentifiedObject(energySourcePhase=obj.to_pb())
+            elif isinstance(obj, Junction):
+                nio = NetworkIdentifiedObject(junction=obj.to_pb())
+            elif isinstance(obj, PowerTransformer):
+                nio = NetworkIdentifiedObject(powerTransformer=obj.to_pb())
+            else:
+                raise Exception(f"Missing class in create response - you should implement it: {str(obj)}")
+        elif isinstance(obj, ConnectivityNode):
+            nio = NetworkIdentifiedObject(connectivityNode=obj.to_pb())
+        elif isinstance(obj, EnergySourcePhase):
+            nio = NetworkIdentifiedObject(energySourcePhase=obj.to_pb())
+        elif isinstance(obj, Feeder):
+            nio = NetworkIdentifiedObject(feeder=obj.to_pb())
+        elif isinstance(obj, Location):
+            nio = NetworkIdentifiedObject(location=obj.to_pb())
+        elif isinstance(obj, OverheadWireInfo):
+            nio = NetworkIdentifiedObject(overheadWireInfo=obj.to_pb())
+        elif isinstance(obj, PerLengthSequenceImpedance):
+            nio = NetworkIdentifiedObject(perLengthSequenceImpedance=obj.to_pb())
+        elif isinstance(obj, PowerTransformerEnd):
+            nio = NetworkIdentifiedObject(powerTransformerEnd=obj.to_pb())
+        elif isinstance(obj, Substation):
+            nio = NetworkIdentifiedObject(substation=obj.to_pb())
+        elif isinstance(obj, Terminal):
+            nio = NetworkIdentifiedObject(terminal=obj.to_pb())
+        else:
+            raise Exception(f"Missing class in create response - you should implement it: {str(obj)}")
+        og.identifiedObject.CopyFrom(nio)
+        responses.append(GetIdentifiedObjectsResponse(objectGroup=og))
+    return responses

--- a/test/test_consumer.py
+++ b/test/test_consumer.py
@@ -8,94 +8,137 @@ from typing import List
 import pytest
 from hypothesis import given, settings, Phase
 from zepben.protobuf.nc.nc_data_pb2 import NetworkIdentifiedObject
-from zepben.protobuf.nc.nc_requests_pb2 import GetIdentifiedObjectsRequest
-from zepben.protobuf.nc.nc_responses_pb2 import GetIdentifiedObjectsResponse, GetEquipmentForContainerResponse
+from zepben.protobuf.nc.nc_requests_pb2 import GetIdentifiedObjectsRequest, GetEquipmentForContainerRequest, GetCurrentEquipmentForFeederRequest, \
+    GetEquipmentForRestrictionRequest
+from zepben.protobuf.nc.nc_responses_pb2 import GetIdentifiedObjectsResponse, GetEquipmentForContainerResponse, GetCurrentEquipmentForFeederResponse, \
+    GetEquipmentForRestrictionResponse
 from unittest.mock import MagicMock
 
 from test.pb_creators import networkidentifiedobjects, aclinesegment
 from zepben.evolve import NetworkConsumerClient, NetworkService, IdentifiedObject, CableInfo, ConductingEquipment, AcLineSegment, Breaker, EnergySource, \
     EnergySourcePhase, Junction, PowerTransformer, PowerTransformerEnd, ConnectivityNode, Feeder, Location, OverheadWireInfo, PerLengthSequenceImpedance, \
-    Substation, Terminal, EquipmentContainer
+    Substation, Terminal, EquipmentContainer, Equipment, BaseService, OperationalRestriction
 
 
 # TODO: Test behaviour of "failures" with get_feeder/get_identified_objects
 
-class TestConsumer(object):
-
-    @pytest.mark.asyncio
-    @given(networkidentifiedobjects())
-    @settings(max_examples=1, phases=(Phase.explicit, Phase.reuse, Phase.generate))
-    async def test_retrieve_supported_types(self, networkidentifiedobjects):
-        network_service = NetworkService()
-        for nio in networkidentifiedobjects:
-            response = GetIdentifiedObjectsResponse(identifiedObject=nio)
-            stub = MagicMock(**{"getIdentifiedObjects.return_value": [response]})
-            client = NetworkConsumerClient(stub=stub)
-            pbio = getattr(nio, nio.WhichOneof("identifiedObject"), None)
-            result = await client.get_identified_objects(network_service, [pbio.mrid()])
-            assert result.was_successful
-            if pbio.mrid():
-                assert result.result.value[pbio.mrid()] is not None, f"type: {nio.WhichOneof('identifiedObject')} mrid: {pbio.mrid()}"
-                assert network_service.get(pbio.mrid()) is result.result.value[pbio.mrid()]
-            else:
-                assert pbio.mrid() in result.result.failed
-
-    @pytest.mark.asyncio
-    @given(aclinesegment())
-    async def test_get_identifiedobject(self, aclinesegment):
-        network_service = NetworkService()
-        nio = NetworkIdentifiedObject(acLineSegment=aclinesegment)
+@pytest.mark.asyncio
+@given(networkidentifiedobjects())
+@settings(max_examples=1, phases=(Phase.explicit, Phase.reuse, Phase.generate))
+async def test_retrieve_supported_types(networkidentifiedobjects):
+    network_service = NetworkService()
+    for nio in networkidentifiedobjects:
         response = GetIdentifiedObjectsResponse(identifiedObject=nio)
         stub = MagicMock(**{"getIdentifiedObjects.return_value": [response]})
         client = NetworkConsumerClient(stub=stub)
         pbio = getattr(nio, nio.WhichOneof("identifiedObject"), None)
-        result = await client.get_identified_object(network_service, pbio.mrid())
+        result = await client.get_identified_objects(network_service, [pbio.mrid()])
         assert result.was_successful
-        assert result.result is not None
-        assert result.result.mrid == pbio.mrid()
+        if pbio.mrid():
+            assert result.result.value[pbio.mrid()] is not None, f"type: {nio.WhichOneof('identifiedObject')} mrid: {pbio.mrid()}"
+            assert network_service.get(pbio.mrid()) is result.result.value[pbio.mrid()]
+        else:
+            assert pbio.mrid() in result.result.failed
 
-        stub = MagicMock(**{"getIdentifiedObjects.return_value": []})
-        client = NetworkConsumerClient(stub=stub)
-        pbio = getattr(nio, nio.WhichOneof("identifiedObject"), None)
-        result = await client.get_identified_object(network_service, "fakemrid")
-        assert result.was_successful
-        assert result.result is None
 
-    @pytest.mark.asyncio
-    async def test_get_network_hierarchy(self, feeder_network):
-        pass
+@pytest.mark.asyncio
+@given(aclinesegment())
+async def test_get_identifiedobject(aclinesegment):
+    network_service = NetworkService()
+    nio = NetworkIdentifiedObject(acLineSegment=aclinesegment)
+    response = GetIdentifiedObjectsResponse(identifiedObject=nio)
+    stub = MagicMock(**{"getIdentifiedObjects.return_value": [response]})
+    client = NetworkConsumerClient(stub=stub)
+    pbio = getattr(nio, nio.WhichOneof("identifiedObject"), None)
+    result = await client.get_identified_object(network_service, pbio.mrid())
+    assert result.was_successful
+    assert result.result is not None
+    assert result.result.mrid == pbio.mrid()
 
-    @pytest.mark.asyncio
-    async def test_retrieve_network(self):
-        pass
+    stub = MagicMock(**{"getIdentifiedObjects.return_value": []})
+    client = NetworkConsumerClient(stub=stub)
+    pbio = getattr(nio, nio.WhichOneof("identifiedObject"), None)
+    result = await client.get_identified_object(network_service, "fakemrid")
+    assert result.was_successful
+    assert result.result is None
 
-    @pytest.mark.asyncio
-    async def test_get_feeder(self, feeder_network):
-        ns = NetworkService()
-        feeder_mrid = "f001"
 
-        def create_feeder_response(request: GetIdentifiedObjectsRequest, *args, **kwargs):
-            for mrid in request.mrids:
-                io = feeder_network.get(mrid)
-                yield response_of(io, GetIdentifiedObjectsResponse)
+@pytest.mark.asyncio
+async def test_get_network_hierarchy(feeder_network):
+    pass
 
-        def create_equipment_response(request: GetIdentifiedObjectsRequest, *args, **kwargs):
-            ec = feeder_network.get(request.mrid, EquipmentContainer)
-            for equip in ec.equipment:
-                yield response_of(equip, GetEquipmentForContainerResponse)
 
-        stub = MagicMock(**{"getIdentifiedObjects.side_effect": create_feeder_response, "getEquipmentForContainer.side_effect": create_equipment_response})
-        client = NetworkConsumerClient(stub=stub)
-        objects = await client.get_feeder(ns, feeder_mrid)
-        assert len(objects.result.value) == ns.len_of() == 21
-        assert objects.was_successful
-        assert feeder_mrid in objects.result.value
-        for io in objects.result.value.values():
-            assert ns.get(io.mrid) == io
+@pytest.mark.asyncio
+async def test_retrieve_network():
+    pass
 
-        for io in ns.objects():
-            assert objects.result.value[io.mrid] == io
-        assert len(objects.result.failed) == 0
+
+@pytest.mark.asyncio
+async def test_get_feeder(feeder_network):
+    ns = NetworkService()
+    feeder_mrid = "f001"
+
+    def create_feeder_response(request: GetIdentifiedObjectsRequest, *args, **kwargs):
+        for mrid in request.mrids:
+            io = feeder_network.get(mrid)
+            yield response_of(io, GetIdentifiedObjectsResponse)
+
+    stub = MagicMock(
+        **{"getIdentifiedObjects.side_effect": create_feeder_response, "getEquipmentForContainer.side_effect": create_container_equipment_func(feeder_network)})
+    client = NetworkConsumerClient(stub=stub)
+    objects = await client.get_feeder(ns, feeder_mrid)
+    assert len(objects.result.value) == ns.len_of() == 21
+    assert objects.was_successful
+    assert feeder_mrid in objects.result.value
+    for io in objects.result.value.values():
+        assert ns.get(io.mrid) == io
+
+    for io in ns.objects():
+        assert objects.result.value[io.mrid] == io
+    assert len(objects.result.failed) == 0
+
+
+@pytest.mark.asyncio
+async def test_get_equipment_for_container(feeder_network):
+    ns = NetworkService()
+    feeder_mrid = "f001"
+
+    stub = MagicMock(**{"getEquipmentForContainer.side_effect": create_container_equipment_func(feeder_network)})
+    client = NetworkConsumerClient(stub=stub)
+    objects = await client.get_equipment_for_container(ns, feeder_mrid)
+    assert len(objects.result.value) == ns.len_of(Equipment) == 3
+    assert_contains_mrids(ns, "fsp", "c2", "tx")
+
+
+@pytest.mark.asyncio
+async def test_get_current_equipment_for_feeder(feeder_with_current):
+    ns = NetworkService()
+    feeder_mrid = "f001"
+    stub = MagicMock(**{"getEquipmentForContainer.side_effect": create_container_equipment_func(feeder_with_current), "getCurrentEquipmentForFeeder.side_effect": create_container_current_equipment_func(feeder_with_current)})
+    client = NetworkConsumerClient(stub=stub)
+    objects = await client.get_equipment_for_container(ns, feeder_mrid)
+    assert len(objects.result.value) == ns.len_of(Equipment) == 7
+    assert_contains_mrids(ns, "fsp", "c2", "tx", "c3", "sw", "c4", "tx2")
+    ns2 = NetworkService()
+    objects = await client.get_current_equipment_for_feeder(ns2, feeder_mrid)
+    assert len(objects.result.value) == ns2.len_of(Equipment) == 5
+    assert_contains_mrids(ns2, "fsp", "c2", "tx", "c3", "sw")
+
+
+@pytest.mark.asyncio
+async def test_get_equipment_for_operational_restriction(operational_restriction_with_equipment):
+    ns = NetworkService()
+    or_mrid = "or1"
+    stub = MagicMock(**{"getEquipmentForRestriction.side_effect": create_restriction_equipment_func(operational_restriction_with_equipment)})
+    client = NetworkConsumerClient(stub=stub)
+    objects = await client.get_equipment_for_restriction(ns, or_mrid)
+    assert len(objects.result.value) == ns.len_of(Equipment) == 3
+    assert_contains_mrids(ns, "fsp", "c2", "tx")
+
+
+def assert_contains_mrids(service: BaseService, *mrids):
+    for mrid in mrids:
+        assert service.get(mrid)
 
 
 def response_of(object: IdentifiedObject, response_type):
@@ -141,3 +184,30 @@ def to_networkidentifiedobject(obj) -> NetworkIdentifiedObject:
     else:
         raise Exception(f"Missing class in create response - you should implement it: {str(obj)}")
     return nio
+
+
+def create_container_equipment_func(network: NetworkService):
+    def create_equipment_response(request: GetEquipmentForContainerRequest, *args, **kwargs):
+        ec = network.get(request.mrid, EquipmentContainer)
+        for equip in ec.equipment:
+            yield response_of(equip, GetEquipmentForContainerResponse)
+
+    return create_equipment_response
+
+
+def create_restriction_equipment_func(network: NetworkService):
+    def create_equipment_response(request: GetEquipmentForRestrictionRequest, *args, **kwargs):
+        or1 = network.get(request.mrid, OperationalRestriction)
+        for equip in or1.equipment:
+            yield response_of(equip, GetEquipmentForRestrictionResponse)
+
+    return create_equipment_response
+
+
+def create_container_current_equipment_func(network: NetworkService):
+    def create_equipment_response(request: GetCurrentEquipmentForFeederRequest, *args, **kwargs):
+        ec = network.get(request.mrid, Feeder)
+        for equip in ec.current_equipment:
+            yield response_of(equip, GetCurrentEquipmentForFeederResponse)
+
+    return create_equipment_response

--- a/test/test_consumer.py
+++ b/test/test_consumer.py
@@ -7,15 +7,15 @@ from typing import List
 
 import pytest
 from hypothesis import given, settings, Phase
-from zepben.protobuf.nc.nc_data_pb2 import NetworkIdentifiedObject, IdentifiedObjectGroup
+from zepben.protobuf.nc.nc_data_pb2 import NetworkIdentifiedObject
 from zepben.protobuf.nc.nc_requests_pb2 import GetIdentifiedObjectsRequest
-from zepben.protobuf.nc.nc_responses_pb2 import GetIdentifiedObjectsResponse
+from zepben.protobuf.nc.nc_responses_pb2 import GetIdentifiedObjectsResponse, GetEquipmentForContainerResponse
 from unittest.mock import MagicMock
 
 from test.pb_creators import networkidentifiedobjects, aclinesegment
 from zepben.evolve import NetworkConsumerClient, NetworkService, IdentifiedObject, CableInfo, ConductingEquipment, AcLineSegment, Breaker, EnergySource, \
     EnergySourcePhase, Junction, PowerTransformer, PowerTransformerEnd, ConnectivityNode, Feeder, Location, OverheadWireInfo, PerLengthSequenceImpedance, \
-    Substation, Terminal
+    Substation, Terminal, EquipmentContainer
 
 
 # TODO: Test behaviour of "failures" with get_feeder/get_identified_objects
@@ -28,7 +28,7 @@ class TestConsumer(object):
     async def test_retrieve_supported_types(self, networkidentifiedobjects):
         network_service = NetworkService()
         for nio in networkidentifiedobjects:
-            response = GetIdentifiedObjectsResponse(objectGroup=IdentifiedObjectGroup(identifiedObject=nio))
+            response = GetIdentifiedObjectsResponse(identifiedObject=nio)
             stub = MagicMock(**{"getIdentifiedObjects.return_value": [response]})
             client = NetworkConsumerClient(stub=stub)
             pbio = getattr(nio, nio.WhichOneof("identifiedObject"), None)
@@ -45,7 +45,7 @@ class TestConsumer(object):
     async def test_get_identifiedobject(self, aclinesegment):
         network_service = NetworkService()
         nio = NetworkIdentifiedObject(acLineSegment=aclinesegment)
-        response = GetIdentifiedObjectsResponse(objectGroup=IdentifiedObjectGroup(identifiedObject=nio))
+        response = GetIdentifiedObjectsResponse(identifiedObject=nio)
         stub = MagicMock(**{"getIdentifiedObjects.return_value": [response]})
         client = NetworkConsumerClient(stub=stub)
         pbio = getattr(nio, nio.WhichOneof("identifiedObject"), None)
@@ -74,18 +74,20 @@ class TestConsumer(object):
         ns = NetworkService()
         feeder_mrid = "f001"
 
-        def create_feeder_responses(request: GetIdentifiedObjectsRequest, *args, **kwargs):
-            objects = []
+        def create_feeder_response(request: GetIdentifiedObjectsRequest, *args, **kwargs):
             for mrid in request.mrids:
                 io = feeder_network.get(mrid)
-                if io:
-                    objects.append(io)
-            return response_of(objects)
+                yield response_of(io, GetIdentifiedObjectsResponse)
 
-        stub = MagicMock(**{"getIdentifiedObjects.side_effect": create_feeder_responses})
+        def create_equipment_response(request: GetIdentifiedObjectsRequest, *args, **kwargs):
+            ec = feeder_network.get(request.mrid, EquipmentContainer)
+            for equip in ec.equipment:
+                yield response_of(equip, GetEquipmentForContainerResponse)
+
+        stub = MagicMock(**{"getIdentifiedObjects.side_effect": create_feeder_response, "getEquipmentForContainer.side_effect": create_equipment_response})
         client = NetworkConsumerClient(stub=stub)
         objects = await client.get_feeder(ns, feeder_mrid)
-        assert len(objects.result.value) == ns.len_of() == feeder_network.len_of()
+        assert len(objects.result.value) == ns.len_of() == 21
         assert objects.was_successful
         assert feeder_mrid in objects.result.value
         for io in objects.result.value.values():
@@ -96,48 +98,46 @@ class TestConsumer(object):
         assert len(objects.result.failed) == 0
 
 
-def response_of(objects: List[IdentifiedObject]):
-    responses = []
-    for obj in objects:
-        og = IdentifiedObjectGroup()
-        if isinstance(obj, CableInfo):
-            nio = NetworkIdentifiedObject(cableInfo=obj.to_pb())
-        elif isinstance(obj, ConductingEquipment):
-            # og.ownedIdentifiedObject.extend([NetworkIdentifiedObject(terminal=t.to_pb()) for t in obj.terminals])
-            if isinstance(obj, AcLineSegment):
-                nio = NetworkIdentifiedObject(acLineSegment=obj.to_pb())
-            elif isinstance(obj, Breaker):
-                nio = NetworkIdentifiedObject(breaker=obj.to_pb())
-            elif isinstance(obj, EnergySource):
-                nio = NetworkIdentifiedObject(energySource=obj.to_pb())
-            elif isinstance(obj, EnergySourcePhase):
-                nio = NetworkIdentifiedObject(energySourcePhase=obj.to_pb())
-            elif isinstance(obj, Junction):
-                nio = NetworkIdentifiedObject(junction=obj.to_pb())
-            elif isinstance(obj, PowerTransformer):
-                nio = NetworkIdentifiedObject(powerTransformer=obj.to_pb())
-            else:
-                raise Exception(f"Missing class in create response - you should implement it: {str(obj)}")
-        elif isinstance(obj, ConnectivityNode):
-            nio = NetworkIdentifiedObject(connectivityNode=obj.to_pb())
+def response_of(object: IdentifiedObject, response_type):
+    return response_type(identifiedObject=to_networkidentifiedobject(object))
+
+
+def to_networkidentifiedobject(obj) -> NetworkIdentifiedObject:
+    if isinstance(obj, CableInfo):
+        nio = NetworkIdentifiedObject(cableInfo=obj.to_pb())
+    elif isinstance(obj, ConductingEquipment):
+        if isinstance(obj, AcLineSegment):
+            nio = NetworkIdentifiedObject(acLineSegment=obj.to_pb())
+        elif isinstance(obj, Breaker):
+            nio = NetworkIdentifiedObject(breaker=obj.to_pb())
+        elif isinstance(obj, EnergySource):
+            nio = NetworkIdentifiedObject(energySource=obj.to_pb())
         elif isinstance(obj, EnergySourcePhase):
             nio = NetworkIdentifiedObject(energySourcePhase=obj.to_pb())
-        elif isinstance(obj, Feeder):
-            nio = NetworkIdentifiedObject(feeder=obj.to_pb())
-        elif isinstance(obj, Location):
-            nio = NetworkIdentifiedObject(location=obj.to_pb())
-        elif isinstance(obj, OverheadWireInfo):
-            nio = NetworkIdentifiedObject(overheadWireInfo=obj.to_pb())
-        elif isinstance(obj, PerLengthSequenceImpedance):
-            nio = NetworkIdentifiedObject(perLengthSequenceImpedance=obj.to_pb())
-        elif isinstance(obj, PowerTransformerEnd):
-            nio = NetworkIdentifiedObject(powerTransformerEnd=obj.to_pb())
-        elif isinstance(obj, Substation):
-            nio = NetworkIdentifiedObject(substation=obj.to_pb())
-        elif isinstance(obj, Terminal):
-            nio = NetworkIdentifiedObject(terminal=obj.to_pb())
+        elif isinstance(obj, Junction):
+            nio = NetworkIdentifiedObject(junction=obj.to_pb())
+        elif isinstance(obj, PowerTransformer):
+            nio = NetworkIdentifiedObject(powerTransformer=obj.to_pb())
         else:
             raise Exception(f"Missing class in create response - you should implement it: {str(obj)}")
-        og.identifiedObject.CopyFrom(nio)
-        responses.append(GetIdentifiedObjectsResponse(objectGroup=og))
-    return responses
+    elif isinstance(obj, ConnectivityNode):
+        nio = NetworkIdentifiedObject(connectivityNode=obj.to_pb())
+    elif isinstance(obj, EnergySourcePhase):
+        nio = NetworkIdentifiedObject(energySourcePhase=obj.to_pb())
+    elif isinstance(obj, Feeder):
+        nio = NetworkIdentifiedObject(feeder=obj.to_pb())
+    elif isinstance(obj, Location):
+        nio = NetworkIdentifiedObject(location=obj.to_pb())
+    elif isinstance(obj, OverheadWireInfo):
+        nio = NetworkIdentifiedObject(overheadWireInfo=obj.to_pb())
+    elif isinstance(obj, PerLengthSequenceImpedance):
+        nio = NetworkIdentifiedObject(perLengthSequenceImpedance=obj.to_pb())
+    elif isinstance(obj, PowerTransformerEnd):
+        nio = NetworkIdentifiedObject(powerTransformerEnd=obj.to_pb())
+    elif isinstance(obj, Substation):
+        nio = NetworkIdentifiedObject(substation=obj.to_pb())
+    elif isinstance(obj, Terminal):
+        nio = NetworkIdentifiedObject(terminal=obj.to_pb())
+    else:
+        raise Exception(f"Missing class in create response - you should implement it: {str(obj)}")
+    return nio

--- a/test/test_network_to_cim.py
+++ b/test/test_network_to_cim.py
@@ -35,7 +35,7 @@ from zepben.protobuf.cim.iec61970.base.wires.ProtectedSwitch_pb2 import Protecte
 from zepben.protobuf.cim.iec61970.base.wires.Switch_pb2 import Switch as PBSwitch
 
 from zepben.evolve.services.network.network import NetworkService
-from zepben.evolve.services.network.translator.network_proto2cim import NetworkProtoToCim
+import zepben.evolve.services.network.translator.network_proto2cim
 
 
 class TestNetworkToCim(object):
@@ -43,7 +43,7 @@ class TestNetworkToCim(object):
         """Test addition to the network works for CableInfo PB type."""
 
         # Create network
-        network = NetworkProtoToCim(NetworkService())
+        network = NetworkService()
 
         # BaseVoltage1
         io_bv1 = PBIdentifiedObject(mRID="bv1", name="bv1")
@@ -125,4 +125,4 @@ class TestNetworkToCim(object):
         me = PBMeter(ed=ed)
         network.add_from_pb(me)
 
-        print(network.service)
+        print(network)

--- a/test/test_reference_resolvers.py
+++ b/test/test_reference_resolvers.py
@@ -14,7 +14,7 @@ def test_resolves_acls_plsi():
     acls = AcLineSegment(per_length_sequence_impedance=plsi)
     br = resolver.per_length_sequence_impedance(acls)
     ns.resolve_or_defer_reference(br, plsi.mrid)
-    assert plsi.mrid in ns.get_unresolved_reference_mrids(br)
+    assert plsi.mrid in ns.get_unresolved_reference_mrids_by_resolver(br)
     ns.add(acls)
     acls_fetched = ns.get(acls.mrid)
     assert acls_fetched.per_length_sequence_impedance == plsi
@@ -22,10 +22,11 @@ def test_resolves_acls_plsi():
     ns = NetworkService()
     ns.add(plsi)
     ns.resolve_or_defer_reference(resolver.per_length_sequence_impedance(acls), plsi.mrid)
-    assert len(list(ns.get_unresolved_reference_mrids(br))) == 0
+    assert len(list(ns.get_unresolved_reference_mrids_by_resolver(br))) == 0
     ns.add(acls)
     acls_fetched = ns.get(acls.mrid)
     assert acls_fetched.per_length_sequence_impedance == plsi
+
 
 def test_resolves_pt_pti():
     ns = NetworkService()
@@ -36,7 +37,7 @@ def test_resolves_pt_pti():
     br = resolver.power_transformer_info(pt)
     ns.resolve_or_defer_reference(br, pti.mrid)
 
-    assert pti.mrid in ns.get_unresolved_reference_mrids(br)
+    assert pti.mrid in ns.get_unresolved_reference_mrids_by_resolver(br)
 
     ns.add(pt)
     pt_fetched = ns.get(pt.mrid)
@@ -45,10 +46,11 @@ def test_resolves_pt_pti():
     ns = NetworkService()
     ns.add(pti)
     ns.resolve_or_defer_reference(resolver.power_transformer_info(pt), pti.mrid)
-    assert len(list(ns.get_unresolved_reference_mrids(br))) == 0
+    assert len(list(ns.get_unresolved_reference_mrids_by_resolver(br))) == 0
     ns.add(pt)
     pt_fetched = ns.get(pt.mrid)
     assert pt_fetched.asset_info == pti
+
 
 def test_resolves_pole_streetlight():
     ns = NetworkService()
@@ -57,8 +59,10 @@ def test_resolves_pole_streetlight():
     pole.add_streetlight(streetlight)
     br = resolver.streetlights(pole)
     ns.resolve_or_defer_reference(br, streetlight.mrid)
-    assert streetlight.mrid in ns.get_unresolved_reference_mrids(br)
+    assert str(streetlight.mrid) in ns.get_unresolved_reference_mrids_by_resolver(br)
+    ns.add(pole)
+    assert len(list(ns.get_unresolved_reference_mrids_by_resolver(br))) == 1
     ns.add(streetlight)
-    assert len(list(ns.get_unresolved_reference_mrids(br))) == 0
+    assert len(list(ns.get_unresolved_reference_mrids_by_resolver(br))) == 0
     streetlight_fetched = ns.get(streetlight.mrid)
     assert streetlight == streetlight_fetched

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ allowlist_externals = /bin/bash
     /usr/bin/bash
 passenv = GITHUB_*
 setenv = COVERALLS_REPO_TOKEN = {env:COVERALLS_REPO_TOKEN:}
+pip_pre = true
 deps =
     .[test]
     coveralls


### PR DESCRIPTION
@charlta @gcarwardine 

So this PR does a few things but notably makes get_feeder resolve all references rather than the previous subset of types.
From what I understand Carlos isn't currently blocked on this as he has a workaround at the moment, so it's not a huge rush. It requires some thought and may be slightly controversial (although hopefully not)

The other big change is around unresolved references - I've changed them to be indexed in two ways: "from" and "to". 
The "to" map is an index over to_mrid (as it was previously) and there is now a new "from" map which has the reverse. Both maps always contain the same data, they are just indexed differently.

This allows for some more efficient querying of unresolved references, as you can easily get all the references for an object by its mRID, rather than having to iterate over all the unresolved references.

The drawback is the additional memory cost. From my experimenting this is only really a significant cost when you pull in a Feeder, and it's not that bad. We essentially double the amount of references held in memory, but this is only for a limited time while you are resolving references, and the memory use of the maps drops twice as fast as it used to as you resolve references.

For my test feeder of ~18000 objects the memory usage was insignificant, so I'd only expect it to be problematic if we started getting up to the 100 thousands or millions on a single feeder.

I also made the maps values sets rather than lists to enhance lookup times - which previously was quite expensive when deferring references or adding new objects.
And finally I made `UnresolvedReference.from` an mRID rather than an `IdentifiedObject` - this was just during my debugging and it's not strictly needed, but I've left it in there for the moment as I think it's cleaner/easier to understand. The drawback is that you can't immediately resolve a reference for an object that's _not_ in the service, however I don't think we should really be allowing that anyway as it could be misleading for users.

I know it's all in python but you should be able to get the gist of it pretty easily, the important parts are in base_service.py, network_consumer.py. 

