### PR TITLE
PROJ-524 - Major rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ You can generate the [coverage report](htmlcov/index.html) using the following o
  pytest --cov=zepben.evolve --cov-report=html --cov-branch
  ```
 
+If you need to debug an async test, you will need to annotate the test with the following
+to prevent the test from timing out while you step through the code:
+
+```
+@pytest.mark.timeout(100000)
+```
+
 ## Checklist for model changes ##
 
 1. Update [`setup.py`](setup.py) to import the correct version of `zepben.protobuf`.

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@
 * `get_identified_object` now returns a `ValueError` error if the requested object does not exist rather than a `null` successful result.
 * Renamed `get_terminals_for_connectivitynode` to `get_terminals_for_connectivity_node` in `NetworkConsumerClient`.
 * Renamed `value` to `objects` in `MultiObjectResult`.
+* All `CimConsumerClient` implementations have been changed to control a single service rather than one per call.
+* All SDK methods that retrieve objects with references will now request the network hierarchy first to provide
+  a consistent result, regardless of call order.
+* Updated to use v0.15.0 gRPC protocols.
 
 ##### New Features
 * Added the following CIM classes:
@@ -31,6 +35,7 @@ through `zepben.evolve.services.network.network_extensions`.
 ##### Fixes
 * `get_identified_objects` now adds unknown mRIDs to the failed collection.
 * Fixed typing issues on all services.
+* Circuits now correctly link to loops when received via gRPC.
 
 ##### Notes
 * None.

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_namespace_packages
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-test_deps = ["pytest", "pytest-cov", "pytest-asyncio", "hypothesis<6"]
+test_deps = ["pytest", "pytest-cov", "pytest-asyncio", "pytest-timeout", "hypothesis<6", "grpcio-testing==1.36.0"]
 setup(
     name="zepben.evolve",
     version="0.23.0b15",
@@ -35,7 +35,7 @@ setup(
     install_requires=[
         "protobuf==3.14.0",
         "requests<2.26.0,>=2.25.0",
-        "zepben.protobuf==0.14.0",
+        "zepben.protobuf==0.15.0b1",
         "python-jose-cryptodome>=1.3.2,<1.4.0",
         "dataclassy==0.6.2",
         "grpcio==1.36.0"

--- a/src/zepben/evolve/model/cim/iec61970/base/core/terminal.py
+++ b/src/zepben/evolve/model/cim/iec61970/base/core/terminal.py
@@ -7,8 +7,11 @@
 from __future__ import annotations
 
 from typing import Optional
+from typing import TYPE_CHECKING
 from weakref import ref, ReferenceType
 
+if TYPE_CHECKING:
+    from zepben.evolve import ConnectivityNode, ConductingEquipment
 from zepben.evolve.model.cim.iec61970.base.core.identified_object import IdentifiedObject
 from zepben.evolve.model.cim.iec61970.base.core.phase_code import PhaseCode
 from zepben.evolve.model.phases import TracedPhases
@@ -44,7 +47,7 @@ class Terminal(AcDcTerminal):
     """the phase object representing the traced phases in both the normal and current network. If properly configured you would expect the normal state phases 
     to match those in `phases`"""
 
-    _cn: ReferenceType = None
+    _cn: Optional[ReferenceType] = None
     """This is a weak reference to the connectivity node so if a Network object goes out of scope, holding a single conducting equipment
     reference does not cause everything connected to it in the network to stay in memory."""
 
@@ -70,14 +73,17 @@ class Terminal(AcDcTerminal):
 
     @property
     def connectivity_node(self):
-        try:
+        if self._cn:
             return self._cn()
-        except TypeError:
+        else:
             return None
 
     @connectivity_node.setter
-    def connectivity_node(self, cn):
-        self._cn = ref(cn)
+    def connectivity_node(self, cn: Optional[ConnectivityNode]):
+        if cn:
+            self._cn = ref(cn)
+        else:
+            self._cn = None
 
     @property
     def connected(self) -> bool:
@@ -111,4 +117,3 @@ class Terminal(AcDcTerminal):
 
     def disconnect(self):
         self.connectivity_node = None
-

--- a/src/zepben/evolve/services/network/tracing/util.py
+++ b/src/zepben/evolve/services/network/tracing/util.py
@@ -6,6 +6,10 @@
 
 from __future__ import annotations
 import logging
+from typing import Optional
+
+from zepben.evolve import Switch, ConductingEquipment, SinglePhaseKind
+from zepben.evolve.services.network.tracing.queuing_functions import tracing_logger
 from zepben.evolve.services.network.tracing.traversals.tracing import Traversal
 from zepben.evolve.services.network.tracing.traversals.queue import LifoQueue
 from zepben.evolve.services.network.tracing.phases.phase_status import normal_phases, current_phases
@@ -21,9 +25,10 @@ def normally_open(equip: ConductingEquipment, phase: Optional[SinglePhaseKind] =
     `phase` The Phase to test. If None tests all phases.
     Returns True if the equipment is open (de-energised), False otherwise
     """
-    try:
+    if isinstance(equip, Switch):
+        # noinspection PyUnresolvedReferences
         return not equip.normally_in_service or equip.is_normally_open(phase)
-    except AttributeError:
+    else:
         return not equip.normally_in_service
 
 
@@ -34,9 +39,10 @@ def currently_open(equip: ConductingEquipment, phase: Optional[SinglePhaseKind] 
     `phase` The phase to test. If None tests all phases.
     Returns True if the equipment is open (de-energised), False otherwise
     """
-    try:
+    if isinstance(equip, Switch):
+        # noinspection PyUnresolvedReferences
         return not equip.in_service or equip.is_open(phase)
-    except AttributeError:
+    else:
         return not equip.in_service
 
 

--- a/src/zepben/evolve/services/network/translator/network_proto2cim.py
+++ b/src/zepben/evolve/services/network/translator/network_proto2cim.py
@@ -834,6 +834,7 @@ def transformerend_to_cim(pb: PBTransformerEnd, cim: TransformerEnd, network_ser
 
 def circuit_to_cim(pb: PBCircuit, network_service: NetworkService) -> Optional[Circuit]:
     cim = Circuit(mrid=pb.mrid())
+    network_service.resolve_or_defer_reference(resolver.loop(cim), pb.loopMRID)
     for mrid in pb.endTerminalMRIDs:
         network_service.resolve_or_defer_reference(resolver.end_terminal(cim), mrid)
     for mrid in pb.endSubstationMRIDs:

--- a/src/zepben/evolve/streaming/get/consumer.py
+++ b/src/zepben/evolve/streaming/get/consumer.py
@@ -10,11 +10,11 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Iterable, Dict, Set, TypeVar, Generic, Tuple, Optional, AsyncGenerator
+from typing import Iterable, Dict, Set, TypeVar, Generic, Tuple, Optional, AsyncGenerator, Type, Generator
 
 from dataclassy import dataclass
 
-from zepben.evolve import BaseService, IdentifiedObject
+from zepben.evolve import BaseService, IdentifiedObject, UnsupportedOperationException
 from zepben.evolve.streaming.grpc.grpc import GrpcClient, GrpcResult
 
 __all__ = ["CimConsumerClient", "MultiObjectResult"]
@@ -27,6 +27,8 @@ class MultiObjectResult(object):
 
 
 ServiceType = TypeVar('ServiceType', bound=BaseService)
+PBIdentifiedObject = TypeVar('PBIdentifiedObject')
+GrpcRequest = TypeVar('GrpcRequest')
 
 
 class CimConsumerClient(GrpcClient, Generic[ServiceType]):
@@ -43,8 +45,15 @@ class CimConsumerClient(GrpcClient, Generic[ServiceType]):
         T: The base service to send objects from.
     """
 
+    @property
     @abstractmethod
-    async def get_identified_object(self, service: ServiceType, mrid: str) -> GrpcResult[IdentifiedObject]:
+    def service(self) -> ServiceType:
+        """
+        The service to store all retrieved objects in.
+        """
+        raise NotImplementedError()
+
+    async def get_identified_object(self, mrid: str) -> GrpcResult[IdentifiedObject]:
         """
         Retrieve the object with the given `mRID` and store the result in the `service`.
 
@@ -56,10 +65,9 @@ class CimConsumerClient(GrpcClient, Generic[ServiceType]):
                 - :class:`NoSuchElementException` if the object could not be found.
                 - The gRPC error that occurred while retrieving the object
         """
-        raise NotImplementedError()
+        return await self._get_identified_object(mrid)
 
-    @abstractmethod
-    async def get_identified_objects(self, service: ServiceType, mrids: Iterable[str]) -> GrpcResult[MultiObjectResult]:
+    async def get_identified_objects(self, mrids: Iterable[str]) -> GrpcResult[MultiObjectResult]:
         """
         Retrieve the objects with the given `mRIDs` and store the results in the `service`.
 
@@ -73,7 +81,65 @@ class CimConsumerClient(GrpcClient, Generic[ServiceType]):
 
         Note the :class:`CimConsumerClient` warning in this case.
         """
+        return await self._get_identified_objects(mrids)
+
+    async def _get_identified_object(self, mrid: str) -> GrpcResult[Optional[IdentifiedObject]]:
+        async def rpc():
+            async for io, _ in self._process_identified_objects([mrid]):
+                return io
+            else:
+                raise ValueError(f"No object with mRID {mrid} could be found.")
+
+        return await self.try_rpc(rpc)
+
+    async def _get_identified_objects(self, mrids: Iterable[str]) -> GrpcResult[MultiObjectResult]:
+        async def rpc():
+            return await self._process_extract_results(mrids, self._process_identified_objects(set(mrids)))
+
+        return await self.try_rpc(rpc)
+
+    @abstractmethod
+    async def _process_identified_objects(self, mrids: Iterable[str]) -> AsyncGenerator[Tuple[Optional[IdentifiedObject], str], None]:
+        #
+        # NOTE: this is a stupid test that is meant to fail to make sure we never yield, but we need to have the yield to make it return the generator.
+        #
+        if self is None:
+            yield
         raise NotImplementedError()
+
+    CIM_TYPE = TypeVar("CIM_TYPE", bound=IdentifiedObject)
+
+    def _extract_identified_object(self,
+                                   desc: str,
+                                   pb_io: PBIdentifiedObject,
+                                   pb_type_to_cim: Dict[str, Type[CIM_TYPE]],
+                                   check_presence: bool = True) -> Tuple[Optional[IdentifiedObject], str]:
+        """
+        Add a :class:`CustomerIdentifiedObject` to the service. Will convert from protobuf to CIM type.
+
+        Parameters
+            - `pb_io` - The wrapped identified object returned by the server.
+            - `pb_type_to_cim` - The mapping of wrapped identified object types to CIM objects.
+            - `check_presence` - Whether to check if `cio` already exists in the service and skip if it does.
+
+        Raises :class:`UnsupportedOperationException` if `pb_io` was invalid/unset.
+        """
+        io_type = pb_io.WhichOneof("identifiedObject")
+        if io_type:
+            cim_type = pb_type_to_cim.get(io_type, None)
+            if cim_type is None:
+                raise UnsupportedOperationException(f"Identified object type '{io_type}' is not supported by the {desc} service")
+
+            pb = getattr(pb_io, io_type)
+            if check_presence:
+                cim = self.service.get(pb.mrid(), cim_type, default=None)
+                if cim is not None:
+                    return cim, cim.mrid
+
+            # noinspection PyUnresolvedReferences
+            return self.service.add_from_pb(pb), pb.mrid()
+        else:
+            raise UnsupportedOperationException(f"Received a {desc} identified object where no field was set")
 
     @staticmethod
     async def _process_extract_results(mrids: Iterable[str], extracted: AsyncGenerator[Tuple[Optional[IdentifiedObject], str], None]) -> MultiObjectResult:
@@ -86,3 +152,16 @@ class CimConsumerClient(GrpcClient, Generic[ServiceType]):
                 failed.remove(result[0].mrid)
 
         return MultiObjectResult(results, failed)
+
+    @staticmethod
+    def _batch_send(request: GrpcRequest, mrids: Iterable[str]) -> Generator[GrpcRequest, None, None]:
+        count = 0
+        for mrid in mrids:
+            count += 1
+            if count % 1000 == 0:
+                yield request
+                del request.mrids[:]
+            request.mrids.append(mrid)
+
+        if request.mrids:
+            yield request

--- a/src/zepben/evolve/streaming/get/customer_consumer.py
+++ b/src/zepben/evolve/streaming/get/customer_consumer.py
@@ -12,13 +12,12 @@ from __future__ import annotations
 from asyncio import get_event_loop
 from typing import Optional, Iterable, AsyncGenerator, List, Callable, Tuple
 
-from zepben.protobuf.cc.cc_data_pb2 import CustomerIdentifiedObject
-
-from zepben.evolve import CustomerService, IdentifiedObject, UnsupportedOperationException, Organisation, Customer, CustomerAgreement, PricingStructure, Tariff
-from zepben.evolve.streaming.get.consumer import CimConsumerClient, MultiObjectResult
-from zepben.evolve.streaming.grpc.grpc import GrpcResult
 from zepben.protobuf.cc.cc_pb2_grpc import CustomerConsumerStub
 from zepben.protobuf.cc.cc_requests_pb2 import GetIdentifiedObjectsRequest
+
+from zepben.evolve import CustomerService, IdentifiedObject, Organisation, Customer, CustomerAgreement, PricingStructure, Tariff
+from zepben.evolve.streaming.get.consumer import CimConsumerClient, MultiObjectResult
+from zepben.evolve.streaming.grpc.grpc import GrpcResult
 
 __all__ = ["CustomerConsumerClient", "SyncCustomerConsumerClient"]
 
@@ -34,6 +33,12 @@ class CustomerConsumerClient(CimConsumerClient[CustomerService]):
         check for mRIDs that were not found or retrieved but not added to service (this should not be the case unless you are processing things concurrently).
     """
 
+    __service: CustomerService
+
+    @property
+    def service(self) -> CustomerService:
+        return self.__service
+
     _stub: CustomerConsumerStub = None
 
     def __init__(self, channel=None, stub: CustomerConsumerStub = None, error_handlers: List[Callable[[Exception], bool]] = None):
@@ -45,114 +50,25 @@ class CustomerConsumerClient(CimConsumerClient[CustomerService]):
         else:
             self._stub = CustomerConsumerStub(channel)
 
-    async def get_identified_object(self, service: CustomerService, mrid: str) -> GrpcResult[IdentifiedObject]:
-        """
-        Retrieve the object with the given `mRID` and store the result in the `service`.
+        self.__service = CustomerService()
 
-        Exceptions that occur during sending will be caught and passed to all error handlers that have been registered.
-
-        Parameters
-            - `service` - The :class:`CustomerService` to store fetched objects in.
-            - `mRID` - The mRID to retrieve.
-
-        Returns a :class:`GrpcResult` with a result of one of the following:
-            - When `GrpcResult.wasSuccessful`, the item found, accessible via `GrpcResult.value`.
-            - When `GrpcResult.wasFailure`, the error that occurred retrieving or processing the the object, accessible via `GrpcResult.thrown`. One of:
-                - :class:`NoSuchElementException` if the object could not be found.
-                - The gRPC error that occurred while retrieving the object
-        """
-        return await self._get_identified_object(service, mrid)
-
-    async def get_identified_objects(self, service: CustomerService, mrids: Iterable[str]) -> GrpcResult[MultiObjectResult]:
-        """
-        Retrieve the objects with the given [mRIDs] and store the results in the [service].
-
-        Exceptions that occur during processing will be caught and passed to all error handlers that have been registered.
-
-        Parameters
-            - `service` - The :class:`CustomerService` to store fetched objects in.
-            - `mRIDs` - The mRIDs to retrieve.
-
-        Returns a :class:`GrpcResult` with a result of one of the following:
-            - When `GrpcResult.wasSuccessful`, a map containing the retrieved objects keyed by mRID, accessible via `GrpcResult.value`. If an item was not
-              found, or couldn't be added to `service`, it will be excluded from the map and its mRID will be present in `MultiObjectResult.failed` (see
-              `BaseService.add`).
-            - When `GrpcResult.wasFailure`, the error that occurred retrieving or processing the the object, accessible via `GrpcResult.thrown`.
-
-        Note the :class:`CustomerConsumerClient` warning in this case.
-        """
-        return await self._get_identified_objects(service, mrids)
-
-    async def _get_identified_object(self, service: CustomerService, mrid: str) -> GrpcResult[Optional[IdentifiedObject]]:
-        async def rpc():
-            async for io, _ in self._process_identified_objects(service, [mrid]):
-                return io
-            else:
-                raise ValueError(f"No object with mRID {mrid} could be found.")
-
-        return await self.try_rpc(rpc)
-
-    async def _get_identified_objects(self, service: CustomerService, mrids: Iterable[str]) -> GrpcResult[MultiObjectResult]:
-        return await self.try_rpc(lambda: self._process_extract_results(mrids, self._process_identified_objects(service, set(mrids))))
-
-    async def _process_identified_objects(self, service: CustomerService, mrids: Iterable[str]) -> AsyncGenerator[Tuple[Optional[IdentifiedObject], str], None]:
+    async def _process_identified_objects(self, mrids: Iterable[str]) -> AsyncGenerator[Tuple[Optional[IdentifiedObject], str], None]:
         if not mrids:
             return
 
-        to_fetch = set()
-        existing = set()
-        for mrid in mrids:
-            try:
-                io = service.get(mrid)
-                existing.add((io, io.mrid))
-            except KeyError:
-                to_fetch.add(mrid)
-
-        if to_fetch:
-            responses = self._stub.getIdentifiedObjects(GetIdentifiedObjectsRequest(mrids=to_fetch))
-            for response in responses:
-                yield _extract_identified_object(service, response.identifiedObject, check_presence=False)  # Already checked presence above
-
-        for io in existing:
-            yield io
+        responses = self._stub.getIdentifiedObjects(self._batch_send(GetIdentifiedObjectsRequest(), mrids))
+        for response in responses:
+            for cio in response.identifiedObjects:
+                yield self._extract_identified_object("customer", cio, _cio_type_to_cim)
 
 
 class SyncCustomerConsumerClient(CustomerConsumerClient):
 
-    def get_identified_object(self, service: CustomerService, mrid: str) -> GrpcResult[Optional[IdentifiedObject]]:
-        return get_event_loop().run_until_complete(super().get_identified_objects(service, mrid))
+    def get_identified_object(self, mrid: str) -> GrpcResult[Optional[IdentifiedObject]]:
+        return get_event_loop().run_until_complete(super()._get_identified_objects(mrid))
 
-    def get_identified_objects(self, service: CustomerService, mrids: Iterable[str]) -> GrpcResult[MultiObjectResult]:
-        return get_event_loop().run_until_complete(super().get_identified_objects(service, mrids))
-
-
-def _extract_identified_object(service: CustomerService, cio: CustomerIdentifiedObject, check_presence: bool = True) -> Tuple[Optional[IdentifiedObject], str]:
-    """
-    Add a :class:`CustomerIdentifiedObject` to the service. Will convert from protobuf to CIM type.
-
-    Parameters
-        - `service` - The :class:`CustomerService` to add the identified object to.
-        - `cio` - The :class:`CustomerIdentifiedObject` returned by the server.
-        - `check_presence` - Whether to check if `cio` already exists in the service and skip if it does.
-
-    Raises :class:`UnsupportedOperationException` if `cio` was invalid/unset.
-    """
-    io_type = cio.WhichOneof("identifiedObject")
-    if io_type:
-        cim_type = _cio_type_to_cim.get(io_type, None)
-        if cim_type is None:
-            raise UnsupportedOperationException(f"Identified object type '{io_type}' is not supported by the customer service")
-
-        pb = getattr(cio, io_type)
-        if check_presence:
-            cim = service.get(pb.mrid(), cim_type, default=None)
-            if cim is not None:
-                return cim, cim.mrid
-
-        # noinspection PyUnresolvedReferences
-        return service.add_from_pb(pb), pb.mrid()
-    else:
-        raise UnsupportedOperationException(f"Received a CustomerIdentifiedObject where no field was set")
+    def get_identified_objects(self, mrids: Iterable[str]) -> GrpcResult[MultiObjectResult]:
+        return get_event_loop().run_until_complete(super()._get_identified_objects(mrids))
 
 
 _cio_type_to_cim = {

--- a/src/zepben/evolve/streaming/get/diagram_consumer.py
+++ b/src/zepben/evolve/streaming/get/diagram_consumer.py
@@ -12,11 +12,10 @@ from __future__ import annotations
 from asyncio import get_event_loop
 from typing import Optional, Iterable, AsyncGenerator, List, Callable, Tuple
 
-from zepben.protobuf.dc.dc_data_pb2 import DiagramIdentifiedObject
 from zepben.protobuf.dc.dc_pb2_grpc import DiagramConsumerStub
 from zepben.protobuf.dc.dc_requests_pb2 import GetIdentifiedObjectsRequest
 
-from zepben.evolve import DiagramService, IdentifiedObject, UnsupportedOperationException, Diagram, DiagramObject
+from zepben.evolve import DiagramService, IdentifiedObject, Diagram, DiagramObject
 from zepben.evolve.streaming.get.consumer import CimConsumerClient, MultiObjectResult
 from zepben.evolve.streaming.grpc.grpc import GrpcResult
 
@@ -34,6 +33,12 @@ class DiagramConsumerClient(CimConsumerClient[DiagramService]):
         check for mRIDs that were not found or retrieved but not added to service (this should not be the case unless you are processing things concurrently).
     """
 
+    __service: DiagramService
+
+    @property
+    def service(self) -> DiagramService:
+        return self.__service
+
     _stub: DiagramConsumerStub = None
 
     def __init__(self, channel=None, stub: DiagramConsumerStub = None, error_handlers: List[Callable[[Exception], bool]] = None):
@@ -45,114 +50,25 @@ class DiagramConsumerClient(CimConsumerClient[DiagramService]):
         else:
             self._stub = DiagramConsumerStub(channel)
 
-    async def get_identified_object(self, service: DiagramService, mrid: str) -> GrpcResult[IdentifiedObject]:
-        """
-        Retrieve the object with the given `mRID` and store the result in the `service`.
+        self.__service = DiagramService()
 
-        Exceptions that occur during sending will be caught and passed to all error handlers that have been registered.
-
-        Parameters
-            - `service` - The :class:`DiagramService` to store fetched objects in.
-            - `mRID` - The mRID to retrieve.
-
-        Returns a :class:`GrpcResult` with a result of one of the following:
-            - When `GrpcResult.wasSuccessful`, the item found, accessible via `GrpcResult.value`.
-            - When `GrpcResult.wasFailure`, the error that occurred retrieving or processing the the object, accessible via `GrpcResult.thrown`. One of:
-                - :class:`NoSuchElementException` if the object could not be found.
-                - The gRPC error that occurred while retrieving the object
-        """
-        return await self._get_identified_object(service, mrid)
-
-    async def get_identified_objects(self, service: DiagramService, mrids: Iterable[str]) -> GrpcResult[MultiObjectResult]:
-        """
-        Retrieve the objects with the given [mRIDs] and store the results in the [service].
-
-        Exceptions that occur during processing will be caught and passed to all error handlers that have been registered.
-
-        Parameters
-            - `service` - The :class:`DiagramService` to store fetched objects in.
-            - `mRIDs` - The mRIDs to retrieve.
-
-        Returns a :class:`GrpcResult` with a result of one of the following:
-            - When `GrpcResult.wasSuccessful`, a map containing the retrieved objects keyed by mRID, accessible via `GrpcResult.value`. If an item was not
-              found, or couldn't be added to `service`, it will be excluded from the map and its mRID will be present in `MultiObjectResult.failed` (see
-              `BaseService.add`).
-            - When `GrpcResult.wasFailure`, the error that occurred retrieving or processing the the object, accessible via `GrpcResult.thrown`.
-
-        Note the :class:`DiagramConsumerClient` warning in this case.
-        """
-        return await self._get_identified_objects(service, mrids)
-
-    async def _get_identified_object(self, service: DiagramService, mrid: str) -> GrpcResult[Optional[IdentifiedObject]]:
-        async def rpc():
-            async for io, _ in self._process_identified_objects(service, [mrid]):
-                return io
-            else:
-                raise ValueError(f"No object with mRID {mrid} could be found.")
-
-        return await self.try_rpc(rpc)
-
-    async def _get_identified_objects(self, service: DiagramService, mrids: Iterable[str]) -> GrpcResult[MultiObjectResult]:
-        return await self.try_rpc(lambda: self._process_extract_results(mrids, self._process_identified_objects(service, set(mrids))))
-
-    async def _process_identified_objects(self, service: DiagramService, mrids: Iterable[str]) -> AsyncGenerator[Tuple[Optional[IdentifiedObject], str], None]:
+    async def _process_identified_objects(self, mrids: Iterable[str]) -> AsyncGenerator[Tuple[Optional[IdentifiedObject], str], None]:
         if not mrids:
             return
 
-        to_fetch = set()
-        existing = set()
-        for mrid in mrids:
-            try:
-                io = service.get(mrid)
-                existing.add((io, io.mrid))
-            except KeyError:
-                to_fetch.add(mrid)
-
-        if to_fetch:
-            responses = self._stub.getIdentifiedObjects(GetIdentifiedObjectsRequest(mrids=to_fetch))
-            for response in responses:
-                yield _extract_identified_object(service, response.identifiedObject, check_presence=False)  # Already checked presence above
-
-        for io in existing:
-            yield io
+        responses = self._stub.getIdentifiedObjects(self._batch_send(GetIdentifiedObjectsRequest(), mrids))
+        for response in responses:
+            for dio in response.identifiedObjects:
+                yield self._extract_identified_object("diagram", dio, _dio_type_to_cim)
 
 
 class SyncDiagramConsumerClient(DiagramConsumerClient):
 
-    def get_identified_object(self, service: DiagramService, mrid: str) -> GrpcResult[Optional[IdentifiedObject]]:
-        return get_event_loop().run_until_complete(super().get_identified_objects(service, mrid))
+    def get_identified_object(self, mrid: str) -> GrpcResult[Optional[IdentifiedObject]]:
+        return get_event_loop().run_until_complete(super()._get_identified_objects(mrid))
 
-    def get_identified_objects(self, service: DiagramService, mrids: Iterable[str]) -> GrpcResult[MultiObjectResult]:
-        return get_event_loop().run_until_complete(super().get_identified_objects(service, mrids))
-
-
-def _extract_identified_object(service: DiagramService, dio: DiagramIdentifiedObject, check_presence: bool = True) -> Tuple[Optional[IdentifiedObject], str]:
-    """
-    Add a :class:`DiagramIdentifiedObject` to the service. Will convert from protobuf to CIM type.
-
-    Parameters
-        - `service` - The :class:`DiagramService` to add the identified object to.
-        - `dio` - The :class:`DiagramIdentifiedObject` returned by the server.
-        - `check_presence` - Whether to check if `dio` already exists in the service and skip if it does.
-
-    Raises :class:`UnsupportedOperationException` if `dio` was invalid/unset.
-    """
-    io_type = dio.WhichOneof("identifiedObject")
-    if io_type:
-        cim_type = _dio_type_to_cim.get(io_type, None)
-        if cim_type is None:
-            raise UnsupportedOperationException(f"Identified object type '{io_type}' is not supported by the diagram service")
-
-        pb = getattr(dio, io_type)
-        if check_presence:
-            cim = service.get(pb.mrid(), cim_type, default=None)
-            if cim is not None:
-                return cim, cim.mrid
-
-        # noinspection PyUnresolvedReferences
-        return service.add_from_pb(pb), pb.mrid()
-    else:
-        raise UnsupportedOperationException(f"Received a DiagramIdentifiedObject where no field was set")
+    def get_identified_objects(self, mrids: Iterable[str]) -> GrpcResult[MultiObjectResult]:
+        return get_event_loop().run_until_complete(super()._get_identified_objects(mrids))
 
 
 _dio_type_to_cim = {

--- a/test/catching_thread.py
+++ b/test/catching_thread.py
@@ -1,0 +1,15 @@
+import threading
+from typing import Optional
+
+
+class CatchingThread(threading.Thread):
+
+    def __init__(self, target=None, *args, **kwargs):
+        threading.Thread.__init__(self, target=target, daemon=True, *args, **kwargs)
+        self.exception: Optional[Exception] = None
+
+    def run(self):
+        try:
+            threading.Thread.run(self)
+        except Exception as e:
+            self.exception = e

--- a/test/run_streaming.py
+++ b/test/run_streaming.py
@@ -3,37 +3,88 @@
 #  This Source Code Form is subject to the terms of the Mozilla Public
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
-from zepben.evolve import connect, NetworkService
-
-from zepben.evolve.streaming.get.network_consumer import SyncNetworkConsumerClient
 import cProfile
+import platform
+from time import perf_counter, process_time
+from typing import Callable
+
+from zepben.evolve import connect, Feeder
+from zepben.evolve.streaming.get.network_consumer import SyncNetworkConsumerClient
+
+rpc_port = 9001
+indent_level = 0
+indent = 3
+profile = False
+
+
+def run_streaming():
+    print(platform.architecture())
+    _time("get feeder", run_feeder)
+    # This takes about 5:30 if you are not using profiling, about 7:30 if you are, so it is disabled by default.
+    # _time("retrieve network", run_retrieve)
+    _time("retrieve network hierarchy", run_network_hierarchy)
 
 
 def run_retrieve():
-    with connect(rpc_port=50052) as channel:
+    with connect(rpc_port=rpc_port) as channel:
         client = SyncNetworkConsumerClient(channel=channel)
-        result = client.retrieve_network()
-        result.throw_on_error()
-        service = result.result.network_service
-        print(f"Num unresolved: {service.num_unresolved_references()}")
-        print(f"Num objects: {service.len_of()}")
+
+        client.retrieve_network().throw_on_error()
+
+        _log(f"Num unresolved: {client.service.num_unresolved_references()}")
+        _log(f"Num objects: {client.service.len_of()}")
 
 
 def run_feeder():
-    with connect(rpc_port=50052) as channel:
-        service = NetworkService()
+    with connect(rpc_port=rpc_port) as channel:
         client = SyncNetworkConsumerClient(channel=channel)
-        result = client.get_feeder(service, "PBH3A")
-        network = result.result
-        print(f"Num unresolved: {service.num_unresolved_references()}")
-        print(f"Num objects: {service.len_of()}")
+
+        client.get_equipment_container("CTN005", Feeder).throw_on_error()
+
+        _log(f"Num unresolved: {client.service.num_unresolved_references()}")
+        _log(f"Num objects: {client.service.len_of()}")
+
+
+def run_network_hierarchy():
+    with connect(rpc_port=rpc_port) as channel:
+        client = SyncNetworkConsumerClient(channel=channel)
+
+        network_hierarchy = client.get_network_hierarchy().throw_on_error().value
+
+        _log(f"Num geographical regions: {len(network_hierarchy.geographical_regions)}")
+        _log(f"Num sub geographical regions: {len(network_hierarchy.sub_geographical_regions)}")
+        _log(f"Num substations: {len(network_hierarchy.substations)}")
+        _log(f"Num feeders: {len(network_hierarchy.feeders)}")
+        _log(f"Num circuits: {len(network_hierarchy.circuits)}")
+        _log(f"Num loops: {len(network_hierarchy.loops)}")
+
+
+def _time(desc: str, run: Callable[[], None]):
+    start_perf = perf_counter()
+    start_proc = process_time()
+
+    _log(f"Running {desc}...")
+    global indent_level
+    indent_level += 1
+    try:
+        run()
+    except Exception as e:
+        _log(f"Exception caught: {type(e).__name__} - {str(e)}")
+
+    indent_level -= 1
+
+    duration_perf = int(perf_counter() - start_perf)
+    duration_proc = int(process_time() - start_proc)
+    _log(f"{desc} took perf={int(duration_perf / 60)}:{duration_perf % 60:02}, proc={int(duration_proc / 60)}:{duration_proc % 60:02}")
+
+
+def _log(msg: str):
+    c = " "
+    print(f"{c * (indent * indent_level)}{msg}")
 
 
 if __name__ == "__main__":
-    print("running get feeder")
-    # cProfile.run("run_feeder()")
-    run_feeder()
-    print("running retrieve network")
-    # cProfile.run("run_retrieve()")
-    run_retrieve()
+    if profile:
+        cProfile.run("_time(\"streaming\", run_streaming)")
+    else:
+        _time("streaming", run_streaming)

--- a/test/services/network/test_network_extensions.py
+++ b/test/services/network/test_network_extensions.py
@@ -2,11 +2,11 @@ from collections import namedtuple
 
 from pytest import fixture
 
-from zepben.evolve import NetworkService, Junction, BaseVoltage, Terminal, EnergySource, \
+from zepben.evolve import NetworkService, BaseVoltage, Terminal, EnergySource, \
     PowerTransformer, AcLineSegment, EnergyConsumer, PowerTransformerInfo, PositionPoint, Location, \
     ConnectivityNode, Breaker
 
-TestNetworkCreator = namedtuple("TestNetworkCreator", ["net", "bv", "cn1", "cn2", "pt_info", "loc1", "loc2", "loc3"])
+NetworkCreator = namedtuple("TestNetworkCreator", ["net", "bv", "cn1", "cn2", "pt_info", "loc1", "loc2", "loc3"])
 
 
 @fixture()
@@ -21,7 +21,7 @@ def tnc():
     loc1 = Location().add_point(point1)
     loc2 = Location().add_point(point2)
     loc3 = Location().add_point(point2).add_point(point2)
-    yield TestNetworkCreator(net=net, bv=bv, cn1=cn1, cn2=cn2, pt_info=pt_info, loc1=loc1, loc2=loc2, loc3=loc3)
+    yield NetworkCreator(net=net, bv=bv, cn1=cn1, cn2=cn2, pt_info=pt_info, loc1=loc1, loc2=loc2, loc3=loc3)
 
 
 def test_create_energy_source(tnc):

--- a/test/streaming/get/mock_server.py
+++ b/test/streaming/get/mock_server.py
@@ -1,0 +1,97 @@
+from dataclasses import dataclass
+from typing import Awaitable, Callable, List, TypeVar, Union, Optional, Iterable, Generator
+
+import grpc
+import grpc_testing
+# noinspection PyPackageRequirements
+from google.protobuf.descriptor import ServiceDescriptor
+
+from test.catching_thread import CatchingThread
+
+GrpcRequest = TypeVar('GrpcRequest')
+GrpcResponse = TypeVar('GrpcResponse')
+
+
+@dataclass
+class StreamGrpc:
+    function: str
+    processors: List[Callable[[GrpcRequest], Generator[GrpcResponse, None, None]]]
+
+
+@dataclass
+class UnaryGrpc:
+    function: str
+    processor: Callable[[GrpcRequest], Generator[GrpcResponse, None, None]]
+
+
+def stream_from_fixed(expected_requests: List[str], responses: Iterable[GrpcResponse]) -> List[Callable[[GrpcRequest], Generator[GrpcResponse, None, None]]]:
+    def process(request: GrpcRequest) -> Generator[GrpcResponse, None, None]:
+        for response in responses:
+            yield response
+
+        assert len(request.mrids) == len(expected_requests)
+        assert set(request.mrids) == set(expected_requests)
+
+    return [process]
+
+
+def unary_from_fixed(expected_request: Optional[str], response: GrpcResponse):
+    def process(request: GrpcRequest) -> Generator[GrpcResponse, None, None]:
+        yield response
+
+        if expected_request:
+            assert request.mrid == expected_request
+
+    return process
+
+
+class MockServer:
+
+    def __init__(self, channel: grpc_testing.Channel, grpc_service: ServiceDescriptor):
+        self.channel: grpc_testing.Channel = channel
+        self.grpc_service: ServiceDescriptor = grpc_service
+
+    async def validate(self, client_test: Callable[[], Awaitable[None]], interactions: List[Union[StreamGrpc, UnaryGrpc]]):
+        server = CatchingThread(target=self._run_server_logic, args=[interactions])
+        server.start()
+
+        await client_test()
+        server.join()
+
+        if server.exception:
+            raise server.exception
+
+    def _run_server_logic(self, interactions: List[Union[StreamGrpc, UnaryGrpc]]):
+        for i in interactions:
+            if isinstance(i, StreamGrpc):
+                self._run_stream_server_logic(i)
+            elif isinstance(i, UnaryGrpc):
+                self._run_unary_server_logic(i)
+            else:
+                raise NotImplementedError(f"No server logic has been configured for {type(i)}")
+
+    def _run_stream_server_logic(self, interaction: StreamGrpc):
+        for processor in interaction.processors:
+            _, rpc = self.channel.take_stream_stream(self.grpc_service.methods_by_name[interaction.function])
+            rpc.send_initial_metadata(())
+
+            try:
+                request = rpc.take_request()
+
+                for response in processor(request):
+                    rpc.send_response(response)
+
+                rpc.requests_closed()
+            finally:
+                rpc.terminate((), grpc.StatusCode.OK, '')
+
+    def _run_unary_server_logic(self, interaction: UnaryGrpc):
+        _, request, rpc = self.channel.take_unary_unary(self.grpc_service.methods_by_name[interaction.function])
+        rpc.send_initial_metadata(())
+
+        try:
+            for response in interaction.processor(request):
+                rpc.terminate(response, (), grpc.StatusCode.OK, '')
+        except Exception as e:
+            rpc.terminate((), (), grpc.StatusCode.OK, '')
+            raise e

--- a/test/streaming/get/test_consumer.py
+++ b/test/streaming/get/test_consumer.py
@@ -6,25 +6,18 @@
 
 import pytest
 
-from zepben.evolve import BaseService, CimConsumerClient
+from zepben.evolve import CimConsumerClient
 
 
 @pytest.mark.asyncio
 async def test_abstract_coverage():
-    service = BaseService('service')
     client = CimConsumerClient()
-    try:
-        await client.get_identified_object(service, "id")
-        raise AssertionError("Should have thrown")
-    except NotImplementedError:
-        pass
-    except Exception as e:
-        raise e
 
-    try:
-        await client.get_identified_objects(service, ["id"])
-        raise AssertionError("Should have thrown")
-    except NotImplementedError:
-        pass
-    except Exception as e:
-        raise e
+    with pytest.raises(NotImplementedError):
+        (await client.service).throw_on_error()
+
+    with pytest.raises(NotImplementedError):
+        (await client.get_identified_object("id")).throw_on_error()
+
+    with pytest.raises(NotImplementedError):
+        (await client.get_identified_objects(["id"])).throw_on_error()

--- a/tox.ini
+++ b/tox.ini
@@ -20,3 +20,4 @@ log_file_level = DEBUG
 log_file = pytest.log
 log_file_date_format = %Y-%m-%d %H:%M:%S
 log_file_format = %(asctime)s %(levelname)s %(message)s
+timeout = 5


### PR DESCRIPTION
* Updated consumer clients to handle a service rather than each method requiring one.
* Changed to use streaming gRPC calls
* Reworked testing to use in-memory server mock rather than stub mocks to reveal issues with packing/unpacking grpc messages.
* Various small fixes revealed by changing tests.

Signed-off-by: Anthony Charlton <anthony.charlton@zepben.com>