### PR TITLE
Add username and password authentication option to connect_async

### DIFF
--- a/src/zepben/evolve/streaming/grpc/connect.py
+++ b/src/zepben/evolve/streaming/grpc/connect.py
@@ -38,11 +38,15 @@ def _conn(host: str = "localhost", rpc_port: int = 50051, conf_address: str = "h
     `rpc_port` The gRPC port for host.
     `conf_address` The complete address for the auth configuration endpoint. This is used when an `authenticator` is not provided.
 
-    Either client_id and client_secret need to be provided, or authenticator.
+    Either client_id and client_secret need to be provided, or client_id, username, and password, or authenticator.
     `client_id` Optional Your client id for your OAuth Auth provider.
     `client_secret` Corresponding client secret.
 
-    `authenticator` An authenticator that can provide OAuth2 tokens the `host` can validate. If this is provided, it takes precedence over the above client credentials.
+    `client_id` Your client id for your OAuth Auth provider.
+    `username` The username to use for an OAuth password grant.
+    `password` Corresponding password. If both `username` and `password` are provided, it takes precedence over the above client credentials.
+
+    `authenticator` An authenticator that can provide OAuth2 tokens the `host` can validate. If this is provided, it takes precedence over the above credentials.
 
     `pkey` Private key for client authentication
     `cert` Corresponding signed certificate. CN must reflect your hosts FQDN, and must be signed by the servers CA.
@@ -126,7 +130,7 @@ def connect(host: str = "localhost",
     `rpc_port` The gRPC port for host.
     `conf_address` The complete address for the auth configuration endpoint. This is used when an `authenticator` is not provided.
 
-    Either client_id and client_secret need to be provided, client_id, username, and password, or authenticator.
+    Either client_id and client_secret need to be provided, or client_id, username, and password, or authenticator.
     `client_id` Optional Your client id for your OAuth Auth provider.
     `client_secret` Corresponding client secret.
 
@@ -166,7 +170,7 @@ async def connect_async(host: str = "localhost",
     `rpc_port` The gRPC port for host.
     `conf_address` The complete address for the auth configuration endpoint. This is used when an `authenticator` is not provided.
 
-    Either client_id and client_secret need to be provided, or authenticator.
+    Either client_id and client_secret need to be provided, or client_id, username, and password, or authenticator.
     `client_id` Optional Your client id for your OAuth Auth provider.
     `client_secret` Corresponding client secret.
 

--- a/src/zepben/evolve/streaming/grpc/connect.py
+++ b/src/zepben/evolve/streaming/grpc/connect.py
@@ -112,6 +112,8 @@ def connect(host: str = "localhost",
             conf_address: str = "http://localhost/auth",
             client_id: Optional[str] = None,
             client_secret: Optional[str] = None,
+            username: Optional[str] = None,
+            password: Optional[str] = None,
             pkey=None,
             cert=None,
             ca=None,
@@ -124,11 +126,15 @@ def connect(host: str = "localhost",
     `rpc_port` The gRPC port for host.
     `conf_address` The complete address for the auth configuration endpoint. This is used when an `authenticator` is not provided.
 
-    Either client_id and client_secret need to be provided, or authenticator.
+    Either client_id and client_secret need to be provided, client_id, username, and password, or authenticator.
     `client_id` Optional Your client id for your OAuth Auth provider.
     `client_secret` Corresponding client secret.
 
-    `authenticator` An authenticator that can provide OAuth2 tokens the `host` can validate. If this is provided, it takes precedence over the above client credentials.
+    `client_id` Your client id for your OAuth Auth provider.
+    `username` The username to use for an OAuth password grant.
+    `password` Corresponding password. If both `username` and `password` are provided, it takes precedence over the above client credentials.
+
+    `authenticator` An authenticator that can provide OAuth2 tokens the `host` can validate. If this is provided, it takes precedence over the above credentials.
 
     `pkey` Private key for client authentication
     `cert` Corresponding signed certificate. CN must reflect your hosts FQDN, and must be signed by the servers CA.
@@ -137,7 +143,7 @@ def connect(host: str = "localhost",
     Raises `ValueError` upon incompatible arguments.
     Returns a gRPC channel
     """
-    yield _conn(host, rpc_port, conf_address, client_id, client_secret, pkey, cert, ca, authenticator)
+    yield _conn(host, rpc_port, conf_address, client_id, username, password, client_secret, pkey, cert, ca, authenticator)
 
 
 @contextlib.asynccontextmanager
@@ -164,7 +170,11 @@ async def connect_async(host: str = "localhost",
     `client_id` Optional Your client id for your OAuth Auth provider.
     `client_secret` Corresponding client secret.
 
-    `authenticator` An authenticator that can provide OAuth2 tokens the `host` can validate. If this is provided, it takes precedence over the above client credentials.
+    `client_id` Your client id for your OAuth Auth provider.
+    `username` The username to use for an OAuth password grant.
+    `password` Corresponding password. If both `username` and `password` are provided, it takes precedence over the above client credentials.
+
+    `authenticator` An authenticator that can provide OAuth2 tokens the `host` can validate. If this is provided, it takes precedence over the above credentials.
 
     `pkey` Private key for client authentication
     `cert` Corresponding signed certificate. CN must reflect your hosts FQDN, and must be signed by the servers CA.

--- a/src/zepben/evolve/streaming/grpc/connect.py
+++ b/src/zepben/evolve/streaming/grpc/connect.py
@@ -38,11 +38,15 @@ def _conn(host: str = "localhost", rpc_port: int = 50051, conf_address: str = "h
     `rpc_port` The gRPC port for host.
     `conf_address` The complete address for the auth configuration endpoint. This is used when an `authenticator` is not provided.
 
-    Either client_id and client_secret need to be provided, or client_id, username, and password, or authenticator.
-    `client_id` Optional Your client id for your OAuth Auth provider.
-    `client_secret` Corresponding client secret.
+    One of the following sets of arguments must be provided:
+        `client_id` and `client_secret` for client credentials based authentication (usually M2M tokens), or
+        `client_id`, `username`, and `password` for user credentials authentication. Note this is not recommended for untrusted and insecure servers as
+        user credentials will be sent to the server in the clear. Or,
+        `authenticator`, for custom connection options.
 
     `client_id` Your client id for your OAuth Auth provider.
+    `client_secret` Corresponding client secret if required.
+
     `username` The username to use for an OAuth password grant.
     `password` Corresponding password. If both `username` and `password` are provided, it takes precedence over the above client credentials.
 
@@ -130,11 +134,15 @@ def connect(host: str = "localhost",
     `rpc_port` The gRPC port for host.
     `conf_address` The complete address for the auth configuration endpoint. This is used when an `authenticator` is not provided.
 
-    Either client_id and client_secret need to be provided, or client_id, username, and password, or authenticator.
-    `client_id` Optional Your client id for your OAuth Auth provider.
-    `client_secret` Corresponding client secret.
+    One of the following sets of arguments must be provided:
+        `client_id` and `client_secret` for client credentials based authentication (usually M2M tokens), or
+        `client_id`, `username`, and `password` for user credentials authentication. Note this is not recommended for untrusted and insecure servers as
+        user credentials will be sent to the server in the clear. Or,
+        `authenticator`, for custom connection options.
 
     `client_id` Your client id for your OAuth Auth provider.
+    `client_secret` Corresponding client secret if required.
+
     `username` The username to use for an OAuth password grant.
     `password` Corresponding password. If both `username` and `password` are provided, it takes precedence over the above client credentials.
 
@@ -170,11 +178,15 @@ async def connect_async(host: str = "localhost",
     `rpc_port` The gRPC port for host.
     `conf_address` The complete address for the auth configuration endpoint. This is used when an `authenticator` is not provided.
 
-    Either client_id and client_secret need to be provided, or client_id, username, and password, or authenticator.
-    `client_id` Optional Your client id for your OAuth Auth provider.
-    `client_secret` Corresponding client secret.
+    One of the following sets of arguments must be provided:
+        `client_id` and `client_secret` for client credentials based authentication (usually M2M tokens), or
+        `client_id`, `username`, and `password` for user credentials authentication. Note this is not recommended for untrusted and insecure servers as
+        user credentials will be sent to the server in the clear. Or,
+        `authenticator`, for custom connection options.
 
     `client_id` Your client id for your OAuth Auth provider.
+    `client_secret` Corresponding client secret if required.
+
     `username` The username to use for an OAuth password grant.
     `password` Corresponding password. If both `username` and `password` are provided, it takes precedence over the above client credentials.
 


### PR DESCRIPTION
This is a common use case in all the sdk demos, so instead of making the end user jump through hoops and define and pass in their own `ZepbenAuthenticator`, they can simply pass in a `username` and `password` instead, and the appropriate authenticator will be constructed for them.