### PR TITLE
Default arg for ca now causes OS certs to be used.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 ### v0.25.0
 
 ##### Breaking Changes
-* None.
+* Added `secure` flag to `connect()` and `connect_async()` that defaults to False. This flag needs to be True when a secure connection is required or credentials are used.
 
 ##### New Features
 * Added CIM class `ShuntCompensatorInfo`
@@ -11,6 +11,7 @@
 
 ##### Fixes
 * Fixed bug that would cause bus-branch creation mappings to be shared between bus-branch creation result instances.
+* `connect()` and `connect_async()` will now use the OS CA bundle by default if no `ca` is specified.
 
 ##### Notes
 * None.

--- a/docs/docs/consumer.mdx
+++ b/docs/docs/consumer.mdx
@@ -23,23 +23,86 @@ run any analytics you may wish to perform across the whole model.
 
 ## Connecting to a server
 
+The library provides two functions, `connect()` and `connect_async()`. They have the exact same arguments, however the async version is to be used with Python
+asyncio.
+
 ```python
-from zepben.evolve import connect, connect_async, NetworkService, SyncNetworkConsumerClient, NetworkConsumerClient
+from zepben.evolve import connect, connect_async, Feeder, SyncNetworkConsumerClient, NetworkConsumerClient
 
 # Synchronous
 with connect(host="localhost", rpc_port=50051) as channel:
-    service = NetworkService()
     client = SyncNetworkConsumerClient(channel)
-    result = client.get_feeder(service, "xxx")
+    result = client.get_equipment_container("xxx", Feeder)
     # do stuff with service
+    client.service.get('...')
 
 # Asyncio
 async with connect_async(host="localhost", rpc_port=50051) as channel:
-    service = NetworkService()
     client = NetworkConsumerClient(channel)
-    result = await client.get_feeder(service, "xxx")
+    result = await client.get_equipment_container("xxx", Feeder)
     # do stuff with service
+    client.service.get('...')
 ```
+
+### Connecting with HTTPS
+
+To connect to a HTTPS server with no auth all that's needed is the CA for the server. If the CA is in your system certificates it should be picked up
+automatically and the following should suffice:
+
+```python
+with connect(host="ewb.zepben.com", rpc_port=443) as channel:
+    client = SyncNetworkConsumerClient(channel)
+    result = client.get_equipment_container("xxx", Feeder)
+    client.service.get('...')
+```
+
+To specify a CA bundle pass the ca parameter:
+```python
+with open('path/to/ca/bundle', 'rb') as f:
+    ca = f.read()
+
+    with connect(host="ewb.zepben.com", rpc_port=443, ca=ca) as channel:
+        client = SyncNetworkConsumerClient(channel)
+        result = client.get_equipment_container("xxx", Feeder)
+        client.service.get('...')
+```
+
+And if client authentication is required by the server, additionally pass a key and certificate signed by the servers trusted CA:
+```python
+with open(args.key, 'rb') as f:
+    key = f.read()
+with open(args.ca, 'rb') as f:
+    ca = f.read()
+with open(args.cert, 'rb') as f:
+    cert = f.read()
+
+with connect(host="ewb.zepben.com", rpc_port=443, ca=ca, key=key, cert=cert) as channel:
+    client = SyncNetworkConsumerClient(channel)
+    result = client.get_equipment_container("xxx", Feeder)
+    client.service.get('...')
+```
+
+### Authentication
+
+Password Credentials and Client credentials OAuth2 flows are supported through the username/password and client_id/client_secret parameters:
+
+```python
+from zepben.evolve import connect, NetworkService, SyncNetworkConsumerClient
+
+# Password credentials configuration - client_secret optional.
+with connect(host="ewb.zepben.com", rpc_port=443, conf_address="https://ewb.zepben.com/ewb/auth", secure=True, client_id="some_client_id",
+             username="user@email.com", password="password1") as channel:
+    client = SyncNetworkConsumerClient(channel)
+    # ...
+
+# Client credentials configuration
+with connect(host="ewb.zepben.com", rpc_port=443, conf_address="https://ewb.zepben.com/ewb/auth", secure=True, client_id="some_client_id",
+             client_secret="some_client_secret") as channel:
+    client = SyncNetworkConsumerClient(channel)
+    # ...
+```
+
+Custom OAuth2 authenticators can be created by passing an `authenticator` to `connect` or `connect_async`.
 
 ## Network Hierarchy
 

--- a/src/zepben/evolve/streaming/grpc/connect.py
+++ b/src/zepben/evolve/streaming/grpc/connect.py
@@ -8,6 +8,7 @@
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 import contextlib
+import warnings
 from typing import Optional
 
 import grpc
@@ -15,6 +16,8 @@ from zepben.auth import ZepbenAuthenticator, create_authenticator
 
 __all__ = ["connect", "connect_async"]
 _AUTH_HEADER_KEY = 'authorization'
+
+GRPC_READY_TIMEOUT = 5 # seconds
 
 
 class AuthTokenPlugin(grpc.AuthMetadataPlugin):
@@ -30,15 +33,19 @@ class AuthTokenPlugin(grpc.AuthMetadataPlugin):
             callback()
 
 
-def _conn(host: str = "localhost", rpc_port: int = 50051, conf_address: str = "http://localhost/auth", client_id: Optional[str] = None,
+def _conn(host: str = "localhost", rpc_port: int = 50051, conf_address: str = None, client_id: Optional[str] = None,
           username: Optional[str] = None, password: Optional[str] = None, client_secret: Optional[str] = None, pkey=None, cert=None, ca=None,
-          authenticator: Optional[ZepbenAuthenticator] = None):
+          authenticator: Optional[ZepbenAuthenticator] = None, secure: bool = False):
     """
+    Connect to a Zepben gRPC service.
+
     `host` The host to connect to.
     `rpc_port` The gRPC port for host.
-    `conf_address` The complete address for the auth configuration endpoint. This is used when an `authenticator` is not provided.
 
-    One of the following sets of arguments must be provided:
+    `conf_address` The complete address for the auth configuration endpoint. This is used when an `authenticator` is not provided. Defaults to http://<host>/auth
+    `secure` True if SSL is required, False otherwise (default). Must be True for authentication settings to be utilised.
+
+    One of the following sets of arguments must be provided when authentication is configured on the server:
         `client_id` and `client_secret` for client credentials based authentication (usually M2M tokens), or
         `client_id`, `username`, and `password` for user credentials authentication. Note this is not recommended for untrusted and insecure servers as
         user credentials will be sent to the server in the clear. Or,
@@ -52,64 +59,70 @@ def _conn(host: str = "localhost", rpc_port: int = 50051, conf_address: str = "h
 
     `authenticator` An authenticator that can provide OAuth2 tokens the `host` can validate. If this is provided, it takes precedence over the above credentials.
 
-    `pkey` Private key for client authentication
-    `cert` Corresponding signed certificate. CN must reflect your hosts FQDN, and must be signed by the servers CA.
-    `ca` CA trust for the server.
+    `pkey` Private key for client authentication if client authentication is required.
+    `cert` Corresponding signed certificate if client authentication is required. CN must reflect your hosts FQDN, and must be signed by the servers CA.
+    `ca` CA trust for the server, or None to use OS default certificate bundle.
 
-    Raises `ValueError` upon incompatible arguments.
+    Raises `ConnectionError` if unable to make a connection to the server.
     Returns a gRPC channel
     """
-    # Channel credential will be valid for the entire channel
-    channel_credentials = grpc.ssl_channel_credentials(ca, pkey, cert) if ca else None
-    # TODO: make this more robust so it can handle SSL without client verification
-    if ca and authenticator:
-        call_credentials = grpc.metadata_call_credentials(AuthTokenPlugin(authenticator=authenticator))
+    if secure:
+        if conf_address is None:
+            conf_address = f"http://{host}/auth"
+        # Channel credential will be valid for the entire channel
+        channel_credentials = grpc.ssl_channel_credentials(ca, pkey, cert)
+        if authenticator:
+            call_credentials = grpc.metadata_call_credentials(AuthTokenPlugin(authenticator=authenticator))
 
-        # Combining channel credentials and call credentials together
-        composite_credentials = grpc.composite_channel_credentials(
-            channel_credentials,
-            call_credentials,
-        ) if channel_credentials else call_credentials
-        channel = grpc.secure_channel(f"{host}:{rpc_port}", composite_credentials)
-    elif ca and client_id and username and password:
-        # Create a basic ClientCredentials authenticator
-        authenticator = create_authenticator(conf_address)
-        authenticator.token_request_data.update({
-            'client_id': client_id,
-            'username': username,
-            'password': password,
-            'grant_type': 'password',
-            'scope': 'offline_access'
-        })
+            # Combining channel credentials and call credentials together
+            composite_credentials = grpc.composite_channel_credentials(
+                channel_credentials,
+                call_credentials,
+            ) if channel_credentials else call_credentials
+            channel = grpc.secure_channel(f"{host}:{rpc_port}", composite_credentials)
+        elif client_id and username and password:
+            # Create a basic ClientCredentials authenticator
+            authenticator = create_authenticator(conf_address)
+            authenticator.token_request_data.update({
+                'client_id': client_id,
+                'username': username,
+                'password': password,
+                'grant_type': 'password',
+                'scope': 'offline_access'
+            })
 
-        call_credentials = grpc.metadata_call_credentials(AuthTokenPlugin(authenticator))
+            call_credentials = grpc.metadata_call_credentials(AuthTokenPlugin(authenticator))
 
-        # Combining channel credentials and call credentials together
-        composite_credentials = grpc.composite_channel_credentials(
-            channel_credentials,
-            call_credentials,
-        ) if channel_credentials else call_credentials
-        channel = grpc.secure_channel(f"{host}:{rpc_port}", composite_credentials)
-    elif ca and client_id and client_secret:
-        # Create a basic ClientCredentials authenticator
-        authenticator = create_authenticator(conf_address)
-        authenticator.token_request_data.update({'client_id': client_id, 'client_secret': client_secret, 'grant_type': 'client_credentials'})
+            # Combining channel credentials and call credentials together
+            composite_credentials = grpc.composite_channel_credentials(
+                channel_credentials,
+                call_credentials,
+            ) if channel_credentials else call_credentials
+            channel = grpc.secure_channel(f"{host}:{rpc_port}", composite_credentials)
+        elif client_id and client_secret:
+            # Create a basic ClientCredentials authenticator
+            authenticator = create_authenticator(conf_address)
+            authenticator.token_request_data.update({'client_id': client_id, 'client_secret': client_secret, 'grant_type': 'client_credentials'})
 
-        call_credentials = grpc.metadata_call_credentials(AuthTokenPlugin(authenticator))
+            call_credentials = grpc.metadata_call_credentials(AuthTokenPlugin(authenticator))
 
-        # Combining channel credentials and call credentials together
-        composite_credentials = grpc.composite_channel_credentials(
-            channel_credentials,
-            call_credentials,
-        ) if channel_credentials else call_credentials
-        channel = grpc.secure_channel(f"{host}:{rpc_port}", composite_credentials)
-    elif ca and (not client_id and not client_secret and not authenticator):
-        channel = grpc.secure_channel(f"{host}:{rpc_port}", channel_credentials)
-    elif not ca and not client_secret and not client_id and not pkey and not cert and not authenticator:
-        channel = grpc.insecure_channel(f"{host}:{rpc_port}")
+            # Combining channel credentials and call credentials together
+            composite_credentials = grpc.composite_channel_credentials(
+                channel_credentials,
+                call_credentials,
+            ) if channel_credentials else call_credentials
+            channel = grpc.secure_channel(f"{host}:{rpc_port}", composite_credentials)
+        else:
+            channel = grpc.secure_channel(f"{host}:{rpc_port}", channel_credentials)
     else:
-        raise ValueError("Incompatible arguments passed to connect. You must specify at least (client_id, username, password, ca),"
-                         "(client_id, client_secret, ca) or (authenticator, ca) for a secure connection with token based auth.")
+        if client_id or client_secret or username or password or pkey or cert:
+            warnings.warn("An insecure connection is being used but some credentials were specified for connecting, did you forget to set secure=True?")
+        channel = grpc.insecure_channel(f"{host}:{rpc_port}")
+
+    try:
+        grpc.channel_ready_future(channel).result(timeout=GRPC_READY_TIMEOUT)
+    except grpc.FutureTimeoutError as f:
+        raise ConnectionError(f"Timed out connecting to server {host}:{rpc_port}")
 
     return channel
 
@@ -117,7 +130,7 @@ def _conn(host: str = "localhost", rpc_port: int = 50051, conf_address: str = "h
 @contextlib.contextmanager
 def connect(host: str = "localhost",
             rpc_port: int = 50051,
-            conf_address: str = "http://localhost/auth",
+            conf_address: str = None,
             client_id: Optional[str] = None,
             client_secret: Optional[str] = None,
             username: Optional[str] = None,
@@ -125,16 +138,18 @@ def connect(host: str = "localhost",
             pkey=None,
             cert=None,
             ca=None,
-            authenticator: Optional[ZepbenAuthenticator] = None):
+            authenticator: Optional[ZepbenAuthenticator] = None,
+            secure=False):
     """
-    Usage:
-        with connect(args) as channel:
+    Connect to a Zepben gRPC service.
 
     `host` The host to connect to.
     `rpc_port` The gRPC port for host.
-    `conf_address` The complete address for the auth configuration endpoint. This is used when an `authenticator` is not provided.
 
-    One of the following sets of arguments must be provided:
+    `conf_address` The complete address for the auth configuration endpoint. This is used when an `authenticator` is not provided. Defaults to http://<host>/auth
+    `secure` True if SSL is required, False otherwise (default). Must be True for authentication settings to be utilised.
+
+    One of the following sets of arguments must be provided when authentication is configured on the server:
         `client_id` and `client_secret` for client credentials based authentication (usually M2M tokens), or
         `client_id`, `username`, and `password` for user credentials authentication. Note this is not recommended for untrusted and insecure servers as
         user credentials will be sent to the server in the clear. Or,
@@ -148,20 +163,20 @@ def connect(host: str = "localhost",
 
     `authenticator` An authenticator that can provide OAuth2 tokens the `host` can validate. If this is provided, it takes precedence over the above credentials.
 
-    `pkey` Private key for client authentication
-    `cert` Corresponding signed certificate. CN must reflect your hosts FQDN, and must be signed by the servers CA.
-    `ca` CA trust for the server.
+    `pkey` Private key for client authentication if client authentication is required.
+    `cert` Corresponding signed certificate if client authentication is required. CN must reflect your hosts FQDN, and must be signed by the servers CA.
+    `ca` CA trust for the server, or None to use OS default certificate bundle.
 
-    Raises `ValueError` upon incompatible arguments.
+    Raises `ConnectionError` if unable to make a connection to the server.
     Returns a gRPC channel
     """
-    yield _conn(host, rpc_port, conf_address, client_id, username, password, client_secret, pkey, cert, ca, authenticator)
+    yield _conn(host, rpc_port, conf_address, client_id, username, password, client_secret, pkey, cert, ca, authenticator, secure)
 
 
 @contextlib.asynccontextmanager
 async def connect_async(host: str = "localhost",
                         rpc_port: int = 50051,
-                        conf_address: str = "http://localhost/auth",
+                        conf_address: str = None,
                         client_id: Optional[str] = None,
                         client_secret: Optional[str] = None,
                         username: Optional[str] = None,
@@ -169,16 +184,18 @@ async def connect_async(host: str = "localhost",
                         pkey=None,
                         cert=None,
                         ca=None,
-                        authenticator: Optional[ZepbenAuthenticator] = None):
+                        authenticator: Optional[ZepbenAuthenticator] = None,
+                        secure=False):
     """
-    Usage:
-        async with connect_async(args) as channel:
+    Connect to a Zepben gRPC service.
 
     `host` The host to connect to.
     `rpc_port` The gRPC port for host.
-    `conf_address` The complete address for the auth configuration endpoint. This is used when an `authenticator` is not provided.
 
-    One of the following sets of arguments must be provided:
+    `conf_address` The complete address for the auth configuration endpoint. This is used when an `authenticator` is not provided. Defaults to http://<host>/auth
+    `secure` True if SSL is required, False otherwise (default). Must be True for authentication settings to be utilised.
+
+    One of the following sets of arguments must be provided when authentication is configured on the server:
         `client_id` and `client_secret` for client credentials based authentication (usually M2M tokens), or
         `client_id`, `username`, and `password` for user credentials authentication. Note this is not recommended for untrusted and insecure servers as
         user credentials will be sent to the server in the clear. Or,
@@ -192,11 +209,11 @@ async def connect_async(host: str = "localhost",
 
     `authenticator` An authenticator that can provide OAuth2 tokens the `host` can validate. If this is provided, it takes precedence over the above credentials.
 
-    `pkey` Private key for client authentication
-    `cert` Corresponding signed certificate. CN must reflect your hosts FQDN, and must be signed by the servers CA.
-    `ca` CA trust for the server.
+    `pkey` Private key for client authentication if client authentication is required.
+    `cert` Corresponding signed certificate if client authentication is required. CN must reflect your hosts FQDN, and must be signed by the servers CA.
+    `ca` CA trust for the server, or None to use OS default certificate bundle.
 
-    Raises `ValueError` upon incompatible arguments.
+    Raises `ConnectionError` if unable to make a connection to the server.
     Returns a gRPC channel
     """
-    yield _conn(host, rpc_port, conf_address, client_id, username, password, client_secret, pkey, cert, ca, authenticator)
+    yield _conn(host, rpc_port, conf_address, client_id, username, password, client_secret, pkey, cert, ca, authenticator, secure)


### PR DESCRIPTION
This adds an extra boolean argument to connect `secure` that must be set
to true whenever a secure or authenticated connection is required.

Signed-off-by: Kurt Greaves <kurt.greaves@zepben.com>