### PR TITLE
EWB-1239 - Fix grpc connection functions

### DIFF
--- a/src/zepben/evolve/streaming/grpc/channel_builder.py
+++ b/src/zepben/evolve/streaming/grpc/channel_builder.py
@@ -32,19 +32,11 @@ class GrpcChannelBuilder(ABC):
         self._socket_address: str = "localhost:50051"
         self._channel_credentials: Optional[grpc.ChannelCredentials] = None
 
-    def build(self) -> grpc.Channel:
+    def build(self) -> grpc.aio.Channel:
         if self._channel_credentials:
-            return grpc.secure_channel(self._socket_address, self._channel_credentials)
+            return grpc.aio.secure_channel(self._socket_address, self._channel_credentials)
 
-        return grpc.insecure_channel(self._socket_address)
-
-    def connect(self, timeout) -> grpc.Channel:
-        channel = self.build()
-        try:
-            grpc.channel_ready_future(channel).result(timeout=timeout)
-        except grpc.FutureTimeoutError:
-            raise ConnectionError(f"Timed out connecting to server {self._socket_address}")
-        return channel
+        return grpc.aio.insecure_channel(self._socket_address)
 
     def socket_address(self, host: str, port: int) -> 'GrpcChannelBuilder':
         self._socket_address = f"{host}:{port}"

--- a/src/zepben/evolve/streaming/grpc/connect.py
+++ b/src/zepben/evolve/streaming/grpc/connect.py
@@ -16,7 +16,7 @@ from zepben.auth.client import ZepbenTokenFetcher, AuthMethod, create_token_fetc
 
 from zepben.evolve import GrpcChannelBuilder
 
-__all__ = ["connect", "connect_async", "connect_secure", "connect_secure_async", "connect_with_password", "connect_with_password_async"]
+__all__ = ["connect", "connect_async", "connect_secure", "connect_with_password"]
 
 from zepben.evolve.streaming.grpc.channel_builder import AuthTokenPlugin
 

--- a/src/zepben/evolve/streaming/grpc/connect.py
+++ b/src/zepben/evolve/streaming/grpc/connect.py
@@ -51,26 +51,12 @@ def _grpc_channel_builder_from_password(client_id: str, username: str, password:
         .token_fetcher(token_fetcher)
 
 
-@contextlib.contextmanager
-def connect_secure(host: str = "localhost", rpc_port: int = 50051, timeout: float = GRPC_READY_TIMEOUT) -> grpc.Channel:
-    yield _secure_grpc_channel_builder(host, rpc_port).connect(timeout)
+def connect_secure(host: str = "localhost", rpc_port: int = 50051) -> grpc.aio.Channel:
+    return _secure_grpc_channel_builder(host, rpc_port).build()
 
 
-@contextlib.asynccontextmanager
-def connect_secure_async(host: str = "localhost", rpc_port: int = 50051, timeout: float = GRPC_READY_TIMEOUT) -> grpc.Channel:
-    yield _secure_grpc_channel_builder(host, rpc_port).connect(timeout)
-
-
-@contextlib.contextmanager
-def connect_with_password(client_id: str, username: str, password: str, host: str = "localhost", rpc_port: int = 50051,
-                          timeout: float = GRPC_READY_TIMEOUT) -> grpc.Channel:
-    yield _grpc_channel_builder_from_password(client_id, username, password, host, rpc_port).connect(timeout)
-
-
-@contextlib.asynccontextmanager
-def connect_with_password_async(client_id: str, username: str, password: str, host: str = "localhost", rpc_port: int = 50051,
-                                timeout: float = GRPC_READY_TIMEOUT) -> grpc.Channel:
-    yield _grpc_channel_builder_from_password(client_id, username, password, host, rpc_port).connect(timeout)
+def connect_with_password(client_id: str, username: str, password: str, host: str = "localhost", rpc_port: int = 50051) -> grpc.aio.Channel:
+    return _grpc_channel_builder_from_password(client_id, username, password, host, rpc_port).build()
 
 
 def _conn(host: str = "localhost", rpc_port: int = 50051, conf_address: str = None, client_id: Optional[str] = None,


### PR DESCRIPTION
`grpc.aio.Channel` can be `async with`'d, meaning we don't need to make our own context managers.
Signed-off-by: Marcus Koh <marcus.koh@zepben.com>