### PR TITLE
EWB-1458 - `SetPhases` now supports setting backwards through XN/XY transformers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,10 @@
 ##### Breaking Changes
+
 * `queue_next` functions now take an item and a `Traversal`, and they now hold the responsibility of adding the next items to the traversal's queue.
+* Removed `get_connectivity` and `get_connected_equipment` from `connectivity_result.py`. Use `connected_terminals` and `connected_equipment` instead.
 
 ##### New Features
+
 * Allow specification of timeout for CimConsumerClients
 * Added convenience classes `SetPhases` and `RemovePhases` to set and remove phases on a `NetworkService`.
 * Added new `connect_tls()` helper function for connecting to TLS secured EWB with no auth.
@@ -9,10 +12,15 @@
 * Added convenience classes `SetDirection` and `RemoveDirection` to set and remove feeder directions on a `NetworkService`.
 
 ##### Enhancements
-* BusBranchNetworkCreator logic updated so that the factory methods for topological_branches, equivalent_branches, and power_transformers get the topological nodes passed in as arguments sorted by feeder_direction.
+
+* BusBranchNetworkCreator logic updated so that the factory methods for topological_branches, equivalent_branches, and power_transformers get the topological
+  nodes passed in as arguments sorted by feeder_direction.
 
 ##### Fixes
+
 * `connect_with_password()` now works
+* `SetPhases` now supports setting backwards through XN/XY transformers.
 
 ##### Notes
+
 * None.

--- a/src/zepben/evolve/database/sqlite/database_reader.py
+++ b/src/zepben/evolve/database/sqlite/database_reader.py
@@ -9,7 +9,7 @@ from sqlite3 import Connection, Cursor
 from typing import Callable, Optional
 
 from zepben.evolve import MetadataCollection, NetworkService, DiagramService, CustomerService, MetadataEntryReader, DiagramCIMReader, CustomerCIMReader, \
-    TableVersion, MetadataCollectionReader, DiagramServiceReader, CustomerServiceReader, Feeder, EnergySource, get_connected_equipment, ConductingEquipment
+    TableVersion, MetadataCollectionReader, DiagramServiceReader, CustomerServiceReader, Feeder, EnergySource, ConductingEquipment, connected_equipment
 from zepben.evolve.database.sqlite.readers.network_cim_reader import NetworkCIMReader
 from zepben.evolve.database.sqlite.readers.network_service_reader import NetworkServiceReader
 from zepben.evolve.services.network.tracing import tracing
@@ -144,7 +144,7 @@ class DatabaseReader:
         def has_been_assigned_to_feeder(energy_source: EnergySource) -> bool:
             return energy_source.is_external_grid \
                    and self._is_on_feeder(energy_source) \
-                   and get_connected_equipment(energy_source, feeder_start_points)
+                   and feeder_start_points.isdisjoint(set(connected_equipment(energy_source)))
 
         for es in filter(has_been_assigned_to_feeder, network_service.objects(EnergySource)):
             logger.warning(f"External grid source {es} has been assigned to the following feeders: normal {es.normal_feeders}, current {es.current_feeders}")

--- a/src/zepben/evolve/services/network/tracing/connectivity/connectivity_result.py
+++ b/src/zepben/evolve/services/network/tracing/connectivity/connectivity_result.py
@@ -6,16 +6,20 @@
 
 from __future__ import annotations
 
-from typing import List, Optional, Tuple, Set
 from operator import attrgetter
+from typing import List, Optional, Tuple, TYPE_CHECKING
+
 from dataclassy import dataclass
 
-from zepben.evolve.model.cim.iec61970.base.wires.single_phase_kind import SinglePhaseKind
 from zepben.evolve.model.cim.iec61970.base.core.conducting_equipment import ConductingEquipment
 from zepben.evolve.model.cim.iec61970.base.core.terminal import Terminal
+from zepben.evolve.model.cim.iec61970.base.wires.single_phase_kind import SinglePhaseKind
 from zepben.evolve.model.phases import NominalPhasePath
 
-__all__ = ["ConnectivityResult", "get_connectivity", "terminal_compare", "get_connected_equipment"]
+if TYPE_CHECKING:
+    pass
+
+__all__ = ["ConnectivityResult", "terminal_compare"]
 
 
 def terminal_compare(terminal: Terminal, other: Terminal):
@@ -29,81 +33,6 @@ def terminal_compare(terminal: Terminal, other: Terminal):
 
 
 Terminal.__lt__ = terminal_compare
-
-
-def get_connectivity(terminal: Terminal, phases: Set[SinglePhaseKind] = None, exclude=None) -> List[ConnectivityResult]:
-    """
-    Get the connectivity between this terminal and all other terminals in its `ConnectivityNode`.
-    `cores` Core paths to trace between the terminals. Defaults to all cores.
-    `exclude` `zepben.evolve.iec61970.base.core.terminal.Terminal`'s to exclude from the result. Will be skipped if encountered.
-    Returns List of `ConnectivityResult`'s for this terminal.
-    """
-    if exclude is None:
-        exclude = set()
-    if phases is None:
-        phases = set(terminal.phases.single_phases)
-    trace_phases = phases.intersection(terminal.phases.single_phases)
-    cn = terminal.connectivity_node if terminal.connectivity_node else []
-    results = []
-    for term in cn:
-        if terminal is not term and term not in exclude:  # Don't include ourselves, or those specifically excluded.
-            cr = _terminal_connectivity(terminal, term, trace_phases)
-            if cr.nominal_phase_paths:
-                results.append(cr)
-    return results
-
-
-def get_connected_equipment(cond_equip: ConductingEquipment, exclude: Set[ConductingEquipment] = None) -> List[ConductingEquipment]:
-    """
-    Get all `ConductingEquipment` connected to this piece of equipment. An `Equipment` is connected if it has
-    a `zepben.evolve.iec61970.base.core.terminal.Terminal` associated with a `ConnectivityNode` that this `ConductingEquipment` is also associated with.
-
-    `exclude` Equipment to exclude from return.
-    Returns A list of `ConductingEquipment` that are connected to this.
-    """
-    if exclude is None:
-        exclude = set()
-    connected_equip = []
-    for terminal in cond_equip.terminals:
-        conn_node = terminal.connectivity_node
-        for term in conn_node:
-            if term.conducting_equipment in exclude or term.conducting_equipment is None:
-                continue
-            if term != terminal:  # Don't include ourselves.
-                connected_equip.append(term.conducting_equipment)
-    return connected_equip
-
-
-def _terminal_connectivity(terminal: Terminal, connected_terminal: Terminal, phases: Set[SinglePhaseKind]) -> ConnectivityResult:
-    # noinspection PyArgumentList
-    nominal_phase_paths = [NominalPhasePath(phase, phase) for phase in phases if phase in connected_terminal.phases.single_phases]
-
-    if not nominal_phase_paths:
-        xy_phases = {phase for phase in phases if phase == SinglePhaseKind.X or phase == SinglePhaseKind.Y}
-        connected_xy_phases = {phase for phase in connected_terminal.phases.single_phases if phase == SinglePhaseKind.X or phase == SinglePhaseKind.Y}
-
-        _process_xy_phases(terminal, connected_terminal, phases, xy_phases, connected_xy_phases, nominal_phase_paths)
-
-    return ConnectivityResult(from_terminal=terminal, to_terminal=connected_terminal, nominal_phase_paths=nominal_phase_paths)
-
-
-def _process_xy_phases(terminal: Terminal, connected_terminal: Terminal, phases: Set[SinglePhaseKind], xy_phases: Set[SinglePhaseKind],
-                       connected_xy_phases: Set[SinglePhaseKind], nominal_phase_paths: List[NominalPhasePath]):
-    if (not xy_phases and not connected_xy_phases) or (xy_phases and connected_xy_phases):
-        return
-    for phase in xy_phases:
-        i = terminal.phases.single_phases.index(phase)
-        if i < len(connected_terminal.phases.single_phases):
-            # noinspection PyArgumentList
-            nominal_phase_paths.append(NominalPhasePath(from_phase=phase, to_phase=connected_terminal.phases.single_phases[i]))
-
-    for phase in connected_xy_phases:
-        i = connected_terminal.phases.single_phases.index(phase)
-        if i < len(terminal.phases.single_phases):
-            terminal_phase = terminal.phases.single_phases[i]
-            if terminal_phase in phases:
-                # noinspection PyArgumentList
-                nominal_phase_paths.append(NominalPhasePath(from_phase=terminal_phase, to_phase=phase))
 
 
 @dataclass(slots=True, init=False)

--- a/src/zepben/evolve/services/network/tracing/phases/remove_phases.py
+++ b/src/zepben/evolve/services/network/tracing/phases/remove_phases.py
@@ -8,10 +8,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Tuple, Set, Callable, Optional, Union, FrozenSet
 
+from zepben.evolve import connected_terminals
 from zepben.evolve.model.cim.iec61970.base.core.terminal import Terminal
 from zepben.evolve.model.cim.iec61970.base.wires.single_phase_kind import SinglePhaseKind
 from zepben.evolve.model.cim.iec61970.base.core.phase_code import PhaseCode
-from zepben.evolve.services.network.tracing.connectivity.connectivity_result import get_connectivity
 from zepben.evolve.services.network.tracing.phases.phase_status import normal_phases, current_phases
 from zepben.evolve.services.network.tracing.traversals.queue import PriorityQueue
 from zepben.evolve.services.network.tracing.traversals.branch_recursive_tracing import BranchRecursiveTraversal
@@ -76,7 +76,7 @@ def _ebb_and_queue(ebb_phases: EbbPhases, traversal: BranchRecursiveTraversal[Eb
     terminal, nominal_phases = ebb_phases
     ebbed_phases = _ebb(terminal, nominal_phases, phase_selector)
 
-    for cr in get_connectivity(terminal, nominal_phases):
+    for cr in connected_terminals(terminal, nominal_phases):
         _queue_through_equipment(traversal, cr.to_equip, cr.to_terminal, _ebb_from_connected_terminal(ebbed_phases, cr, phase_selector))
 
 

--- a/src/zepben/evolve/testing/test_network_builder.py
+++ b/src/zepben/evolve/testing/test_network_builder.py
@@ -305,9 +305,8 @@ class TestNetworkBuilder(object):
 
         :return: The `NetworkService` created by this `TestNetworkBuilder`
         """
-        # The traces are broken, add them back in later.
-        await set_phases().run(self.network)
         await set_direction().run(self.network)
+        await set_phases().run(self.network)
 
         if apply_directions_from_sources:
             for es in self.network.objects(EnergySource):

--- a/test/services/network/tracing/phases/test_set_phases.py
+++ b/test/services/network/tracing/phases/test_set_phases.py
@@ -5,9 +5,9 @@
 #  file, You can obtain one at https: #mozilla.org/MPL/2.0/.
 import pytest
 
+from test.network_fixtures import phase_swap_loop_network  # noqa (Fixtures)
 from test.services.network.tracing.phases.util import connected_equipment_trace_with_logging, validate_phases, validate_phases_from_term_or_equip, get_t
-from zepben.evolve import SetPhases, EnergySource, ConductingEquipment, Terminal, SinglePhaseKind as SPK, TestNetworkBuilder, PhaseCode, Breaker
-from test.network_fixtures import phase_swap_loop_network # noqa (Fixtures)
+from zepben.evolve import SetPhases, EnergySource, ConductingEquipment, SinglePhaseKind as SPK, TestNetworkBuilder, PhaseCode, Breaker
 from zepben.evolve.exceptions import TracingException, PhaseException
 
 
@@ -46,13 +46,13 @@ async def test_applies_phases_from_sources():
     """
     network_service = await (
         TestNetworkBuilder()
-        .from_source(PhaseCode.ABCN)  # s0
-        .to_acls(PhaseCode.ABCN)  # c1
-        .to_acls(PhaseCode.ABCN)  # c2
-        .branch_from("c1")
-        .to_acls(PhaseCode.AB)  # c3
-        .from_acls(PhaseCode.ABCN)  # c4
-        .build()
+            .from_source(PhaseCode.ABCN)  # s0
+            .to_acls(PhaseCode.ABCN)  # c1
+            .to_acls(PhaseCode.ABCN)  # c2
+            .branch_from("c1")
+            .to_acls(PhaseCode.AB)  # c3
+            .from_acls(PhaseCode.ABCN)  # c4
+            .build()
     )
     await connected_equipment_trace_with_logging(network_service.objects(EnergySource))
 
@@ -72,13 +72,13 @@ async def test_stops_at_open_points():
     """
     network_service = await (
         TestNetworkBuilder()
-        .from_source(PhaseCode.ABCN)  # s0
-        .to_breaker(PhaseCode.ABCN, is_normally_open=True, is_open=False)  # b1
-        .to_acls(PhaseCode.ABCN)  # c2
-        .from_source(PhaseCode.ABCN)  # s3
-        .to_breaker(PhaseCode.ABCN, is_open=True)  # b4
-        .to_acls(PhaseCode.ABCN)  # c5
-        .build()
+            .from_source(PhaseCode.ABCN)  # s0
+            .to_breaker(PhaseCode.ABCN, is_normally_open=True, is_open=False)  # b1
+            .to_acls(PhaseCode.ABCN)  # c2
+            .from_source(PhaseCode.ABCN)  # s3
+            .to_breaker(PhaseCode.ABCN, is_open=True)  # b4
+            .to_acls(PhaseCode.ABCN)  # c5
+            .build()
     )
     await connected_equipment_trace_with_logging(network_service.objects(EnergySource))
 
@@ -99,16 +99,17 @@ async def test_traces_unganged():
     """
     s0 11 b1 21--c2--1
     """
+
     def set_open_status(breaker: Breaker):
         breaker.set_open(True, SPK.A)
         breaker.set_normally_open(True, SPK.B)
 
     network_service = await (
         TestNetworkBuilder()
-        .from_source(PhaseCode.ABCN)  # s0
-        .to_breaker(PhaseCode.ABCN, action=set_open_status)  # b1
-        .to_acls(PhaseCode.ABCN)
-        .build()
+            .from_source(PhaseCode.ABCN)  # s0
+            .to_breaker(PhaseCode.ABCN, action=set_open_status)  # b1
+            .to_acls(PhaseCode.ABCN)
+            .build()
     )
     await connected_equipment_trace_with_logging(network_service.objects(EnergySource))
 
@@ -126,10 +127,10 @@ async def test_can_run_from_terminal():
     """
     network_service = await (
         TestNetworkBuilder()
-        .from_acls(PhaseCode.ABCN)  # c0
-        .to_acls(PhaseCode.ABCN)  # c1
-        .to_acls(PhaseCode.ABCN)  # c2
-        .build()
+            .from_acls(PhaseCode.ABCN)  # c0
+            .to_acls(PhaseCode.ABCN)  # c1
+            .to_acls(PhaseCode.ABCN)  # c2
+            .build()
     )
     await connected_equipment_trace_with_logging(network_service.objects(EnergySource))
 
@@ -147,9 +148,9 @@ async def test_must_provide_the_correct_number_of_phases():
     """
     network_service = await (
         TestNetworkBuilder()
-        .from_acls(PhaseCode.A)  # c0
-        .to_acls(PhaseCode.A)  # c1
-        .build()
+            .from_acls(PhaseCode.A)  # c0
+            .to_acls(PhaseCode.A)  # c1
+            .build()
     )
     await connected_equipment_trace_with_logging(network_service.objects(EnergySource))
 
@@ -167,9 +168,9 @@ async def test_detects_cross_phasing_flow():
     """
     network_service = await (
         TestNetworkBuilder()
-        .from_acls(PhaseCode.A, set_normal_phase(1, SPK.A, SPK.A))
-        .to_acls(PhaseCode.A, set_normal_phase(1, SPK.A, SPK.B))
-        .build()
+            .from_acls(PhaseCode.A, set_normal_phase(1, SPK.A, SPK.A))
+            .to_acls(PhaseCode.A, set_normal_phase(1, SPK.A, SPK.B))
+            .build()
     )
     await connected_equipment_trace_with_logging(network_service.objects(EnergySource))
 
@@ -179,7 +180,7 @@ async def test_detects_cross_phasing_flow():
         await SetPhases().run_with_terminal(get_t(network_service, "c0", 2))
 
     assert e_info.value.args[0] == f"Attempted to flow conflicting phase A onto B on nominal phase A. This occurred while flowing from " \
-                                   f"{list(c1.terminals)[0]} to {list(c1.terminals)[1]} through {c1}. This is caused by missing open "\
+                                   f"{list(c1.terminals)[0]} to {list(c1.terminals)[1]} through {c1}. This is caused by missing open " \
                                    f"points, or incorrect phases in upstream equipment that should be corrected in the source data."
 
 
@@ -190,10 +191,10 @@ async def test_detects_cross_phasing_connected():
     """
     network_service = await (
         TestNetworkBuilder()
-        .from_acls(PhaseCode.A, set_normal_phase(1, SPK.A, SPK.A))
-        .to_acls(PhaseCode.A)
-        .to_acls(PhaseCode.A, set_normal_phase(0, SPK.A, SPK.B))
-        .build()
+            .from_acls(PhaseCode.A, set_normal_phase(1, SPK.A, SPK.A))
+            .to_acls(PhaseCode.A)
+            .to_acls(PhaseCode.A, set_normal_phase(0, SPK.A, SPK.B))
+            .build()
     )
     await connected_equipment_trace_with_logging(network_service.objects(EnergySource))
 
@@ -203,9 +204,53 @@ async def test_detects_cross_phasing_connected():
     with pytest.raises(PhaseException) as e_info:
         await SetPhases().run_with_terminal(get_t(network_service, "c0", 2))
 
-    assert e_info.value.args[0] == f"Attempted to flow conflicting phase A onto B on nominal phase A. This occurred while flowing between "\
-                                   f"{list(c1.terminals)[1]} on {c1} and {list(c2.terminals)[0]} on {c2}. This is caused by "\
+    assert e_info.value.args[0] == f"Attempted to flow conflicting phase A onto B on nominal phase A. This occurred while flowing between " \
+                                   f"{list(c1.terminals)[1]} on {c1} and {list(c2.terminals)[0]} on {c2}. This is caused by " \
                                    f"missing open points, or incorrect phases in upstream equipment that should be corrected in the source data."
+
+
+@pytest.mark.asyncio
+async def test_can_back_trace_through_xn_xy_transformer_loop():
+    """
+       1 tx1 21--\
+    s0 1         c2
+       2 tx3 12--/
+    """
+    network_service = await (
+        TestNetworkBuilder()
+            .from_source(PhaseCode.ABC)  # s0
+            .to_power_transformer([PhaseCode.XY, PhaseCode.XN])  # tx1
+            .to_acls(PhaseCode.XN)  # c2
+            .to_power_transformer([PhaseCode.XN, PhaseCode.XY])  # tx3
+            .connect("tx3", "s0", 2, 1)
+            .build()
+    )
+    await connected_equipment_trace_with_logging(network_service.objects(EnergySource))
+
+    validate_phases_from_term_or_equip(network_service, "s0", PhaseCode.ABC)
+    validate_phases_from_term_or_equip(network_service, "tx1", PhaseCode.AC, PhaseCode.AN)
+    validate_phases_from_term_or_equip(network_service, "c2", PhaseCode.AN, PhaseCode.AN)
+    validate_phases_from_term_or_equip(network_service, "tx3", PhaseCode.AN, PhaseCode.AC)
+
+
+@pytest.mark.asyncio
+async def test_can_back_trace_through_xn_xy_transformer_spur():
+    """
+    s0 11 tx1 21--c2--21 tx3 2
+    """
+    network_service = await (
+        TestNetworkBuilder()
+            .from_source(PhaseCode.ABC)  # s0
+            .to_power_transformer([PhaseCode.XY, PhaseCode.XN])  # tx1
+            .to_acls(PhaseCode.XN)  # c2
+            .to_power_transformer([PhaseCode.XN, PhaseCode.XY])  # tx3
+            .build()
+    )
+
+    validate_phases_from_term_or_equip(network_service, "s0", PhaseCode.ABC)
+    validate_phases_from_term_or_equip(network_service, "tx1", PhaseCode.AC, PhaseCode.AN)
+    validate_phases_from_term_or_equip(network_service, "c2", PhaseCode.AN, PhaseCode.AN)
+    validate_phases_from_term_or_equip(network_service, "tx3", PhaseCode.AN.single_phases, [SPK.A, SPK.NONE])
 
 
 def set_normal_phase(terminal_index, from_phase: SPK, to_phase: SPK):

--- a/test/services/network/tracing/phases/util.py
+++ b/test/services/network/tracing/phases/util.py
@@ -67,7 +67,8 @@ def do_phase_validation(terminal: Terminal, phase_status: PhaseStatus, expected_
     else:
         count = -1
         for (count, (nominal_phase, expected_phase)) in enumerate(zip(terminal.phases.single_phases, expected_phases)):
-            assert phase_status[nominal_phase] == expected_phase, f"nominal phase {nominal_phase}"
+            assert phase_status[nominal_phase] == expected_phase, \
+                f"nominal phase {nominal_phase}. expected {expected_phase}, found {phase_status[nominal_phase]}"
 
         assert len(terminal.phases.single_phases) == count + 1, f"{terminal.phases.single_phases} should be of length {count + 1}"
 

--- a/test/testing/test_test_network_builder.py
+++ b/test/testing/test_test_network_builder.py
@@ -9,7 +9,7 @@ import pytest
 from pytest import raises
 
 from zepben.evolve import start_with_source, PhaseCode, start_with_acls, start_with_breaker, start_with_junction, start_with_power_transformer, \
-    PowerTransformerEnd, start_with_other, Junction, Terminal, NetworkService, ConductingEquipment, get_connectivity, Breaker, Feeder, PowerTransformer
+    PowerTransformerEnd, start_with_other, Junction, Terminal, NetworkService, ConductingEquipment, Breaker, Feeder, PowerTransformer, connected_terminals
 
 
 class TestTestNetworkBuilder(object):
@@ -275,12 +275,12 @@ class TestTestNetworkBuilder(object):
     @staticmethod
     def _validate_terminal_connections(terminal: Terminal, expected_terms: List[str]):
         if expected_terms:
-            diff = set([it.to_terminal.mrid for it in get_connectivity(terminal)]) ^ set(expected_terms)
+            diff = set([it.to_terminal.mrid for it in connected_terminals(terminal)]) ^ set(expected_terms)
             if diff:
                 assert not diff
             assert not diff
         else:
-            assert not get_connectivity(terminal)
+            assert not connected_terminals(terminal)
 
     @staticmethod
     def _validate_open_states(n: NetworkService, mrid: str, expected_is_normally_open: bool, expected_is_open: bool):


### PR DESCRIPTION
* `SetPhases` now supports setting backwards through XN/XY transformers
* Removed `get_connectivity` and `get_connected_equipment` from `connectivity_result.py`

Signed-off-by: Anthony Charlton <anthony.charlton@zepben.com>