### PR TITLE
EWB-1855: Add linked container params for get_equipment_container

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,7 +17,7 @@
 ##### New Features
 
 * Added `LvFeeder`, a branch of LV network starting at a distribution substation and continuing until the end of the LV network.
-* Added the following optional arguments to `NetworkConsumerClient().get_equipment_for_container`:
+* Added the following optional arguments to `NetworkConsumerClient().get_equipment(_for)_container(s)`:
   * `include_energizing_containers`: Specifies whether to include equipment from containers energizing the ones listed in
     `mrids`. This is of the enum type `IncludedEnergizingContainers`, which has three possible values:
     * `EXCLUDE_ENERGIZING_CONTAINERS`: No additional effect (default).

--- a/docs/docs/consumer.mdx
+++ b/docs/docs/consumer.mdx
@@ -68,6 +68,7 @@ with connect_tls(host="ewb.zepben.com", rpc_port=443) as channel:
 To specify a CA bundle pass the ca parameter:
 ```python
 from zepben.evolve import connect_tls, SyncNetworkConsumerClient, Feeder
+from zepben.protobuf.nc.nc_requests_pb2 import INCLUDE_ENERGIZED_LV_FEEDERS
 
 with open('path/to/ca/bundle', 'rb') as f:
     ca = f.read()
@@ -77,7 +78,7 @@ with open('path/to/ca/bundle', 'rb') as f:
 
         result = client.get_equipment_container("xxx", Feeder)
         # The Feeder container only contains HV/MV equipment. To include LV, use the following line instead:
-        # result = client.get_equipment_container("xxx", Feeder, include_energized_containers: INCLUDE_ENERGIZING_LV_FEEDERS)
+        # result = client.get_equipment_container("xxx", Feeder, include_energized_containers=INCLUDE_ENERGIZED_LV_FEEDERS)
 
         client.service.get('...')
 ```
@@ -85,6 +86,7 @@ with open('path/to/ca/bundle', 'rb') as f:
 And if client authentication is required by the server, additionally pass a key and certificate signed by the servers trusted CA:
 ```python
 from zepben.evolve import connect_with_secret, SyncNetworkConsumerClient, Feeder
+from zepben.protobuf.nc.nc_requests_pb2 import INCLUDE_ENERGIZED_LV_FEEDERS
 
 with open(args.key, 'rb') as f:
     key = f.read()
@@ -98,7 +100,7 @@ with connect_with_secret(host="ewb.zepben.com", rpc_port=443, ca=ca, key=key, ce
 
     result = client.get_equipment_container("xxx", Feeder)
     # The Feeder container only contains HV/MV equipment. To include LV, use the following line instead:
-    # result = client.get_equipment_container("xxx", Feeder, include_energized_containers: INCLUDE_ENERGIZING_LV_FEEDERS)
+    # result = client.get_equipment_container("xxx", Feeder, include_energized_containers=INCLUDE_ENERGIZED_LV_FEEDERS)
 
     client.service.get('...')
 ```

--- a/docs/docs/consumer.mdx
+++ b/docs/docs/consumer.mdx
@@ -34,7 +34,7 @@ The library provides four functions, `connect_insecure()`, `connect_tls()`, `con
 The async version is to be used with Python asyncio.
 
 ```python
-from zepben.evolve import connect_insecure, connect_tls, connect_with_password, connect_with_secret, Feeder, SyncNetworkConsumerClient, NetworkConsumerClient
+from zepben.evolve import connect_insecure, Feeder, SyncNetworkConsumerClient, NetworkConsumerClient
 
 # Synchronous
 channel = connect_insecure(host="localhost", rpc_port=50051)
@@ -57,6 +57,8 @@ To connect to a HTTPS server with no auth all that's needed is the CA for the se
 automatically and the following should suffice:
 
 ```python
+from zepben.evolve import connect_tls, SyncNetworkConsumerClient, Feeder
+
 with connect_tls(host="ewb.zepben.com", rpc_port=443) as channel:
     client = SyncNetworkConsumerClient(channel)
     result = client.get_equipment_container("xxx", Feeder)
@@ -65,17 +67,25 @@ with connect_tls(host="ewb.zepben.com", rpc_port=443) as channel:
 
 To specify a CA bundle pass the ca parameter:
 ```python
+from zepben.evolve import connect_tls, SyncNetworkConsumerClient, Feeder
+
 with open('path/to/ca/bundle', 'rb') as f:
     ca = f.read()
 
     with connect_tls(host="ewb.zepben.com", rpc_port=443, ca=ca) as channel:
         client = SyncNetworkConsumerClient(channel)
+
         result = client.get_equipment_container("xxx", Feeder)
+        # The Feeder container only contains HV/MV equipment. To include LV, use the following line instead:
+        # result = client.get_equipment_container("xxx", Feeder, include_energized_containers: INCLUDE_ENERGIZING_LV_FEEDERS)
+
         client.service.get('...')
 ```
 
 And if client authentication is required by the server, additionally pass a key and certificate signed by the servers trusted CA:
 ```python
+from zepben.evolve import connect_with_secret, SyncNetworkConsumerClient, Feeder
+
 with open(args.key, 'rb') as f:
     key = f.read()
 with open(args.ca, 'rb') as f:
@@ -85,7 +95,11 @@ with open(args.cert, 'rb') as f:
 
 with connect_with_secret(host="ewb.zepben.com", rpc_port=443, ca=ca, key=key, cert=cert) as channel:
     client = SyncNetworkConsumerClient(channel)
+
     result = client.get_equipment_container("xxx", Feeder)
+    # The Feeder container only contains HV/MV equipment. To include LV, use the following line instead:
+    # result = client.get_equipment_container("xxx", Feeder, include_energized_containers: INCLUDE_ENERGIZING_LV_FEEDERS)
+
     client.service.get('...')
 ```
 
@@ -94,7 +108,7 @@ with connect_with_secret(host="ewb.zepben.com", rpc_port=443, ca=ca, key=key, ce
 Password Credentials and Client credentials OAuth2 flows are supported through the username/password and client_id/client_secret parameters:
 
 ```python
-from zepben.evolve import connect_with_password, connect_with_secret, NetworkService, SyncNetworkConsumerClient
+from zepben.evolve import connect_with_password, connect_with_secret, SyncNetworkConsumerClient
 
 # Password credentials configuration - client_secret optional.
 with connect_with_password(host="ewb.zepben.com", rpc_port=443, conf_address="https://ewb.zepben.com/ewb/auth", secure=True, client_id="some_client_id",

--- a/src/zepben/evolve/streaming/get/network_consumer.py
+++ b/src/zepben/evolve/streaming/get/network_consumer.py
@@ -90,12 +90,14 @@ class NetworkConsumerClient(CimConsumerClient[NetworkService]):
 
         Parameters
             - `container` - The :class:`EquipmentContainer` (or its mRID) to fetch equipment for.
+            - `include_energizing_containers` - The level of energizing containers to include equipment from.
+            - `include_energized_containers` - The level of energized containers to include equipment from.
 
         Returns a :class:`GrpcResult` with a result of one of the following:
             - When `GrpcResult.wasSuccessful`, a map containing the retrieved objects keyed by mRID, accessible via `GrpcResult.value`. If an item was not
               found, or couldn't be added to `service`, it will be excluded from the map and its mRID will be present in `MultiObjectResult.failed` (see
               `BaseService.add`).
-            - When `GrpcResult.wasFailure`, the error that occurred retrieving or processing the the object, accessible via `GrpcResult.thrown`.
+            - When `GrpcResult.wasFailure`, the error that occurred retrieving or processing the object, accessible via `GrpcResult.thrown`.
 
         Note the :class:`NetworkConsumerClient` warning in this case.
         """
@@ -114,12 +116,14 @@ class NetworkConsumerClient(CimConsumerClient[NetworkService]):
 
         Parameters
             - `containers` - The mRIDs of :class:`EquipmentContainer`'s to fetch equipment for.
+            - `include_energizing_containers` - The level of energizing containers to include equipment from.
+            - `include_energized_containers` - The level of energized containers to include equipment from.
 
         Returns a :class:`GrpcResult` with a result of one of the following:
             - When `GrpcResult.wasSuccessful`, a map containing the retrieved objects keyed by mRID, accessible via `GrpcResult.value`. If an item was not
               found, or couldn't be added to `service`, it will be excluded from the map and its mRID will be present in `MultiObjectResult.failed` (see
               `BaseService.add`).
-            - When `GrpcResult.wasFailure`, the error that occurred retrieving or processing the the object, accessible via `GrpcResult.thrown`.
+            - When `GrpcResult.wasFailure`, the error that occurred retrieving or processing the object, accessible via `GrpcResult.thrown`.
 
         Note the :class:`NetworkConsumerClient` warning in this case.
         """
@@ -139,7 +143,7 @@ class NetworkConsumerClient(CimConsumerClient[NetworkService]):
             - When `GrpcResult.wasSuccessful`, a map containing the retrieved objects keyed by mRID, accessible via `GrpcResult.value`. If an item was not
               found, or couldn't be added to `service`, it will be excluded from the map and its mRID will be present in `MultiObjectResult.failed` (see
               `BaseService.add`).
-            - When `GrpcResult.wasFailure`, the error that occurred retrieving or processing the the object, accessible via `GrpcResult.thrown`.
+            - When `GrpcResult.wasFailure`, the error that occurred retrieving or processing the object, accessible via `GrpcResult.thrown`.
 
         Note the :class:`NetworkConsumerClient` warning in this case.
         """
@@ -159,7 +163,7 @@ class NetworkConsumerClient(CimConsumerClient[NetworkService]):
             - When `GrpcResult.wasSuccessful`, a map containing the retrieved objects keyed by mRID, accessible via `GrpcResult.value`. If an item was not
               found, or couldn't be added to `service`, it will be excluded from the map and its mRID will be present in `MultiObjectResult.failed` (see
               `BaseService.add`).
-            - When `GrpcResult.wasFailure`, the error that occurred retrieving or processing the the object, accessible via `GrpcResult.thrown`.
+            - When `GrpcResult.wasFailure`, the error that occurred retrieving or processing the object, accessible via `GrpcResult.thrown`.
 
         Note the :class:`NetworkConsumerClient` warning in this case.
         """
@@ -179,7 +183,7 @@ class NetworkConsumerClient(CimConsumerClient[NetworkService]):
             - When `GrpcResult.wasSuccessful`, a map containing the retrieved objects keyed by mRID, accessible via `GrpcResult.value`. If an item was not
               found, or couldn't be added to `service`, it will be excluded from the map and its mRID will be present in `MultiObjectResult.failed` (see
               `BaseService.add`).
-            - When `GrpcResult.wasFailure`, the error that occurred retrieving or processing the the object, accessible via `GrpcResult.thrown`.
+            - When `GrpcResult.wasFailure`, the error that occurred retrieving or processing the object, accessible via `GrpcResult.thrown`.
 
         Note the :class:`NetworkConsumerClient` warning in this case.
         """
@@ -216,27 +220,33 @@ class NetworkConsumerClient(CimConsumerClient[NetworkService]):
         warnings.warn('`get_feeder` is deprecated, prefer the more generic `get_equipment_container`', DeprecationWarning)
         return await self._get_equipment_container(mrid, Feeder)
 
-    async def get_equipment_container(self, mrid: str, expected_class: type = EquipmentContainer) -> GrpcResult[MultiObjectResult]:
+    async def get_equipment_container(
+        self,
+        mrid: str,
+        expected_class: type = EquipmentContainer,
+        include_energizing_containers: IncludedEnergizingContainers = IncludedEnergizingContainers.EXCLUDE_ENERGIZING_CONTAINERS,
+        include_energized_containers: IncludedEnergizedContainers = IncludedEnergizedContainers.EXCLUDE_ENERGIZED_CONTAINERS
+    ) -> GrpcResult[MultiObjectResult]:
         """
-        /***
-         * Retrieve the equipment container network for the specified `mrid` and store the results in the `service`.
-         *
-         * This is a convenience method that will fetch the container object and all of the equipment contained, along with all subsequent
-         * references. This should entail a complete connectivity model for the container, however not the connectivity between multiple containers.
-         *
+        Retrieve the equipment container network for the specified `mrid` and store the results in the `service`.
+
+        This is a convenience method that will fetch the container object and all of the equipment contained, along with all subsequent
+        references. This should entail a complete connectivity model for the container, however not the connectivity between multiple containers.
+
         Parameters
-            - `service` - The :class:`NetworkService` to store fetched objects in.
             - `mrid` - The mRID of the :class:`EquipmentContainer` to fetch.
-         * @param expected_class The expected type of the fetched container.
-         *
-         * Returns a :class:`GrpcResult` of a :class:`MultiObjectResult`. If successful, containing a map keyed by mRID of all the objects retrieved. If an
-           item couldn't be added to `service`, its mRID will be present in `MultiObjectResult.failed`.
-         *
-         * In addition to normal gRPC errors, you may also receive an unsuccessful :class:`GrpcResult` with the following errors:
-         * - :class:`ValueError` if the requested object was not found or was of the wrong type.
-         */
+            - `expected_class` - The expected type of the fetched container.
+            - `include_energizing_containers` - The level of energizing containers to include equipment from.
+            - `include_energized_containers` - The level of energized containers to include equipment from.
+
+        Returns a :class:`GrpcResult` of a :class:`MultiObjectResult`. If successful, containing a map keyed by mRID of all the objects retrieved. If an
+        item couldn't be added to `service`, its mRID will be present in `MultiObjectResult.failed`.
+
+        In addition to normal gRPC errors, you may also receive an unsuccessful :class:`GrpcResult` with the following errors:
+            - :class:`ValueError` if the requested object was not found or was of the wrong type.
+
         """
-        return await self._get_equipment_container(mrid, expected_class)
+        return await self._get_equipment_container(mrid, expected_class, include_energizing_containers, include_energized_containers)
 
     async def get_equipment_for_loop(self, loop: Union[str, Loop]) -> GrpcResult[MultiObjectResult]:
         """
@@ -252,7 +262,7 @@ class NetworkConsumerClient(CimConsumerClient[NetworkService]):
             - When `GrpcResult.wasSuccessful`, a map containing the retrieved objects keyed by mRID, accessible via `GrpcResult.value`. If an item was not
               found, or couldn't be added to `service`, it will be excluded from the map and its mRID will be present in `MultiObjectResult.failed` (see
               `BaseService.add`).
-            - When `GrpcResult.wasFailure`, the error that occurred retrieving or processing the the object, accessible via `GrpcResult.thrown`.
+            - When `GrpcResult.wasFailure`, the error that occurred retrieving or processing the object, accessible via `GrpcResult.thrown`.
 
         Note the :class:`NetworkConsumerClient` warning in this case.
         """
@@ -271,7 +281,7 @@ class NetworkConsumerClient(CimConsumerClient[NetworkService]):
             - When `GrpcResult.wasSuccessful`, a map containing the retrieved objects keyed by mRID, accessible via `GrpcResult.value`. If an item was not
               found, or couldn't be added to `service`, it will be excluded from the map and its mRID will be present in `MultiObjectResult.failed` (see
               `BaseService.add`).
-            - When `GrpcResult.wasFailure`, the error that occurred retrieving or processing the the object, accessible via `GrpcResult.thrown`.
+            - When `GrpcResult.wasFailure`, the error that occurred retrieving or processing the object, accessible via `GrpcResult.thrown`.
 
         Note the :class:`NetworkConsumerClient` warning in this case.
         """
@@ -319,9 +329,15 @@ class NetworkConsumerClient(CimConsumerClient[NetworkService]):
             return GrpcResult(self.__network_hierarchy)
         return await self.try_rpc(lambda: self._handle_network_hierarchy())
 
-    async def _get_equipment_container(self, mrid: str, expected_class: type = EquipmentContainer) -> GrpcResult[MultiObjectResult]:
+    async def _get_equipment_container(
+        self,
+        mrid: str,
+        expected_class: type = EquipmentContainer,
+        include_energizing_containers: IncludedEnergizingContainers = IncludedEnergizingContainers.EXCLUDE_ENERGIZING_CONTAINERS,
+        include_energized_containers: IncludedEnergizedContainers = IncludedEnergizedContainers.EXCLUDE_ENERGIZED_CONTAINERS
+    ) -> GrpcResult[MultiObjectResult]:
         async def get_additional(it: EquipmentContainer, mor: MultiObjectResult) -> Optional[GrpcResult[MultiObjectResult]]:
-            result = await self._get_equipment_for_container(it)
+            result = await self._get_equipment_for_container(it, include_energizing_containers, include_energized_containers)
 
             if result.was_failure:
                 # noinspection PyArgumentList
@@ -602,8 +618,16 @@ class SyncNetworkConsumerClient(NetworkConsumerClient):
         warnings.warn('`get_feeder` is deprecated, prefer the more generic `get_equipment_container`', DeprecationWarning)
         return get_event_loop().run_until_complete(super().get_equipment_container(mrid, Feeder))
 
-    def get_equipment_container(self, mrid: str, expected_class: type = EquipmentContainer) -> GrpcResult[MultiObjectResult]:
-        return get_event_loop().run_until_complete(super().get_equipment_container(mrid, expected_class))
+    def get_equipment_container(
+        self,
+        mrid: str,
+        expected_class: type = EquipmentContainer,
+        include_energizing_containers: IncludedEnergizingContainers = IncludedEnergizingContainers.EXCLUDE_ENERGIZING_CONTAINERS,
+        include_energized_containers: IncludedEnergizedContainers = IncludedEnergizedContainers.EXCLUDE_ENERGIZED_CONTAINERS
+    ) -> GrpcResult[MultiObjectResult]:
+        return get_event_loop().run_until_complete(
+            super().get_equipment_container(mrid, expected_class, include_energizing_containers, include_energized_containers)
+        )
 
     def get_equipment_for_loop(self, loop: Union[str, Loop]) -> GrpcResult[MultiObjectResult]:
         # noinspection PyArgumentList

--- a/test/network_fixtures.py
+++ b/test/network_fixtures.py
@@ -10,7 +10,7 @@ from pytest import fixture
 from zepben.evolve import NetworkService, Feeder, PhaseCode, EnergySource, EnergySourcePhase, Junction, ConductingEquipment, Breaker, PowerTransformer, \
     UsagePoint, Terminal, PowerTransformerEnd, Meter, AssetOwner, CustomerService, Organisation, AcLineSegment, \
     PerLengthSequenceImpedance, WireInfo, EnergyConsumer, GeographicalRegion, SubGeographicalRegion, Substation, PowerSystemResource, Location, PositionPoint, \
-    SetPhases, OverheadWireInfo, OperationalRestriction, Equipment, ConnectivityNode, TestNetworkBuilder, LvFeeder, AssignToLvFeeders
+    SetPhases, OverheadWireInfo, OperationalRestriction, Equipment, ConnectivityNode, TestNetworkBuilder, LvFeeder
 
 __all__ = ["create_terminals", "create_junction_for_connecting", "create_source_for_connecting", "create_switch_for_connecting", "create_acls_for_connecting",
            "create_energy_consumer_for_connecting", "create_feeder", "create_substation", "create_power_transformer_for_connecting", "create_terminals",
@@ -305,10 +305,7 @@ async def feeder_network():
     c2 = create_acls_for_connecting(network_service, "c2", PhaseCode.AB)
 
     sub = create_substation(network_service, "f", "f")
-    fdr = create_feeder(network_service, "f001", "f001", sub, fsp.get_terminal_by_sn(2))
-    lvf = LvFeeder(mrid="lvf001", normal_head_terminal=tx.get_terminal_by_sn(2), normal_energizing_feeders=[fdr])
-    fdr.add_normal_energized_lv_feeder(lvf)
-    network_service.add(lvf)
+    create_feeder(network_service, "f001", "f001", sub, fsp.get_terminal_by_sn(2))
 
     add_location(network_service, source, 1.0, 1.0)
     add_location(network_service, fcb, 1.0, 1.0)
@@ -325,7 +322,6 @@ async def feeder_network():
 
     await SetPhases().run(network_service)
     await AssignToFeeders().run(network_service)
-    await AssignToLvFeeders().run(network_service)
     return network_service
 
 

--- a/test/streaming/get/test_network_consumer.py
+++ b/test/streaming/get/test_network_consumer.py
@@ -612,8 +612,8 @@ def _create_object_responses(ns: NetworkService, mrids: Optional[Iterable[str]] 
 def _create_container_responses(
     ns: NetworkService,
     mrids: Optional[Iterable[str]] = None,
-    expected_include_energizing_containers=None,
-    expected_include_energized_containers=None
+    expected_include_energizing_containers: Optional[int] = None,
+    expected_include_energized_containers: Optional[int] = None
 ) \
     -> Callable[[GetEquipmentForContainersRequest], Generator[GetEquipmentForContainersResponse, None, None]]:
     valid: Dict[str, EquipmentContainer] = {mrid: ns[mrid] for mrid in mrids} if mrids else ns

--- a/test/streaming/get/test_network_consumer.py
+++ b/test/streaming/get/test_network_consumer.py
@@ -206,8 +206,8 @@ class TestNetworkConsumer:
         async def client_test():
             mor = (await self.client.get_equipment_container(feeder_mrid, Feeder)).throw_on_error().value
 
-            assert self.service.len_of() == 22
-            assert len(mor.objects) == 21  # we do not include the substation in the results
+            assert self.service.len_of() == 21
+            assert len(mor.objects) == 20  # we do not include the substation in the results
             assert feeder_mrid in mor.objects
             for io in mor.objects.values():
                 assert self.service.get(io.mrid) == io
@@ -240,7 +240,7 @@ class TestNetworkConsumer:
         await self.mock_server.validate(client_test, [UnaryGrpc('getNetworkHierarchy', unary_from_fixed(None, _create_hierarchy_response(feeder_network)))])
 
     @pytest.mark.asyncio
-    async def test_get_equipment_container_with_linked_container_params(self, feeder_network: NetworkService):
+    async def test_get_equipment_container_sends_linked_container_params(self, feeder_network: NetworkService):
         feeder_mrid = "f001"
 
         async def client_test():

--- a/test/streaming/get/test_network_consumer.py
+++ b/test/streaming/get/test_network_consumer.py
@@ -614,8 +614,7 @@ def _create_container_responses(
     mrids: Optional[Iterable[str]] = None,
     expected_include_energizing_containers: Optional[int] = None,
     expected_include_energized_containers: Optional[int] = None
-) \
-    -> Callable[[GetEquipmentForContainersRequest], Generator[GetEquipmentForContainersResponse, None, None]]:
+) -> Callable[[GetEquipmentForContainersRequest], Generator[GetEquipmentForContainersResponse, None, None]]:
     valid: Dict[str, EquipmentContainer] = {mrid: ns[mrid] for mrid in mrids} if mrids else ns
 
     def responses(request: GetEquipmentForContainersRequest) -> Generator[GetEquipmentForContainersResponse, None, None]:

--- a/test/streaming/get/test_network_consumer.py
+++ b/test/streaming/get/test_network_consumer.py
@@ -16,7 +16,7 @@ from hypothesis import given, settings, Phase
 from zepben.evolve import NetworkConsumerClient, NetworkService, IdentifiedObject, CableInfo, AcLineSegment, Breaker, EnergySource, \
     EnergySourcePhase, Junction, PowerTransformer, PowerTransformerEnd, ConnectivityNode, Feeder, Location, OverheadWireInfo, PerLengthSequenceImpedance, \
     Substation, Terminal, EquipmentContainer, Equipment, BaseService, OperationalRestriction, TransformerStarImpedance, GeographicalRegion, \
-    SubGeographicalRegion, Circuit, Loop, Diagram, UnsupportedOperationException
+    SubGeographicalRegion, Circuit, Loop, Diagram, UnsupportedOperationException, LvFeeder
 from zepben.protobuf.nc import nc_pb2
 from zepben.protobuf.nc.nc_data_pb2 import NetworkIdentifiedObject
 from zepben.protobuf.nc.nc_requests_pb2 import GetIdentifiedObjectsRequest, GetEquipmentForContainersRequest, GetCurrentEquipmentForFeederRequest, \
@@ -206,8 +206,8 @@ class TestNetworkConsumer:
         async def client_test():
             mor = (await self.client.get_equipment_container(feeder_mrid, Feeder)).throw_on_error().value
 
-            assert self.service.len_of() == 21
-            assert len(mor.objects) == 20  # we do not include the substation in the results
+            assert self.service.len_of() == 22
+            assert len(mor.objects) == 21  # we do not include the substation in the results
             assert feeder_mrid in mor.objects
             for io in mor.objects.values():
                 assert self.service.get(io.mrid) == io
@@ -238,6 +238,34 @@ class TestNetworkConsumer:
             assert str(response.thrown) == f"Requested mrid {feeder_mrid} was not a Circuit, was Feeder"
 
         await self.mock_server.validate(client_test, [UnaryGrpc('getNetworkHierarchy', unary_from_fixed(None, _create_hierarchy_response(feeder_network)))])
+
+    @pytest.mark.asyncio
+    async def test_get_equipment_container_with_linked_container_params(self, feeder_network: NetworkService):
+        feeder_mrid = "f001"
+
+        async def client_test():
+            await self.client.get_equipment_container(
+                feeder_mrid,
+                Feeder,
+                IncludedEnergizingContainers.INCLUDE_ENERGIZING_SUBSTATIONS,
+                IncludedEnergizedContainers.INCLUDE_ENERGIZED_LV_FEEDERS
+            )
+
+        object_responses = _create_object_responses(feeder_network)
+
+        await self.mock_server.validate(client_test,
+                                        [
+                                            UnaryGrpc('getNetworkHierarchy', unary_from_fixed(None, _create_hierarchy_response(feeder_network))),
+                                            StreamGrpc('getEquipmentForContainers', [
+                                                _create_container_responses(
+                                                    feeder_network,
+                                                    expected_include_energizing_containers=IncludedEnergizingContainers.INCLUDE_ENERGIZING_SUBSTATIONS,
+                                                    expected_include_energized_containers=IncludedEnergizedContainers.INCLUDE_ENERGIZED_LV_FEEDERS
+                                                )
+                                            ]),
+                                            StreamGrpc('getIdentifiedObjects', [object_responses, object_responses])
+                                        ])
+
 
     @pytest.mark.asyncio
     async def test_get_equipment_for_container(self, feeder_network: NetworkService):
@@ -471,7 +499,7 @@ def _to_network_identified_object(obj) -> NetworkIdentifiedObject:
     elif isinstance(obj, Circuit):
         nio = NetworkIdentifiedObject(circuit=obj.to_pb())
     elif isinstance(obj, LvFeeder):
-        nio = NetworkIdentifiedObject(lvfeeder=obj.to_pb())
+        nio = NetworkIdentifiedObject(lvFeeder=obj.to_pb())
     else:
         raise Exception(f"Missing class in create response - you should implement it: {str(obj)}")
     return nio
@@ -581,11 +609,21 @@ def _create_object_responses(ns: NetworkService, mrids: Optional[Iterable[str]] 
     return responses
 
 
-def _create_container_responses(ns: NetworkService, mrids: Optional[Iterable[str]] = None) \
+def _create_container_responses(
+    ns: NetworkService,
+    mrids: Optional[Iterable[str]] = None,
+    expected_include_energizing_containers=None,
+    expected_include_energized_containers=None
+) \
     -> Callable[[GetEquipmentForContainersRequest], Generator[GetEquipmentForContainersResponse, None, None]]:
     valid: Dict[str, EquipmentContainer] = {mrid: ns[mrid] for mrid in mrids} if mrids else ns
 
     def responses(request: GetEquipmentForContainersRequest) -> Generator[GetEquipmentForContainersResponse, None, None]:
+        if expected_include_energizing_containers is not None:
+            assert request.includeEnergizingContainers == expected_include_energizing_containers
+        if expected_include_energized_containers is not None:
+            assert request.includeEnergizedContainers == expected_include_energized_containers
+
         for mrid in request.mrids:
             container = valid[mrid]
             if container:


### PR DESCRIPTION
# Description

This is the Python version of the change in https://github.com/zepben/evolve-sdk-jvm/pull/116. The helper function `get_equipment_container` is used in the python sdk examples and this will allow for an easier transition.

# Associated tasks:

Tasks blocking this one:
- None

Tasks this is blocking:
- https://github.com/zepben/pp-translator/pull/17
- https://github.com/zepben/python-sdk-examples/pull/14

# Checklist:

- [x] I have performed a self review of my own code.
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have updated the changelog.
- [x] I have updated any documentation required for these changes.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have considered if this is a breaking change and have communicated it with other team members if so.
