### PR TITLE
Translate TransformerEnd fields before associating PTE with PT

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -39,6 +39,7 @@
 
 ### Fixes
 * `PhaseCode.num_phases` now correctly returns the number of single phases in a phase code.
+* Fixed issue where `PowerTransformer().ends` was sometimes incorrectly ordered after Protobuf-to-CIM translation.
 
 ### Notes
 * None.

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ test_deps = [
     "pytest-cov==2.10.1",
     "pytest-asyncio==0.19.0",
     "pytest-timeout==1.4.2",
-    "hypothesis<6",
+    "hypothesis==6.56.3",
     "grpcio-testing==1.46.3",
     "pylint==2.14.5"
 ]

--- a/src/zepben/evolve/services/network/translator/network_proto2cim.py
+++ b/src/zepben/evolve/services/network/translator/network_proto2cim.py
@@ -1148,9 +1148,10 @@ def power_transformer_end_to_cim(pb: PBPowerTransformerEnd, network_service: Net
         phase_angle_clock=int_or_none(pb.phaseAngleClock)
     )
 
-    network_service.resolve_or_defer_reference(resolver.power_transformer(cim), pb.powerTransformerMRID)
-
+    # Set end number before associating with power transformer to prevent incorrectly sorted cim.power_transformer.ends
     transformer_end_to_cim(pb.te, cim, network_service)
+
+    network_service.resolve_or_defer_reference(resolver.power_transformer(cim), pb.powerTransformerMRID)
     return cim if network_service.add(cim) else None
 
 

--- a/src/zepben/evolve/streaming/grpc/connect.py
+++ b/src/zepben/evolve/streaming/grpc/connect.py
@@ -103,7 +103,6 @@ def connect_with_secret(client_id: str, client_secret: str, host: str = "localho
     token_fetcher = None
     errors = None
     if conf_path:
-        # TODO EWB-1417 pass through CA (extract from kwargs) for auth conf verification
         token_fetcher = create_token_fetcher(host, port=kwargs.get("port", 443), path=conf_path)
     else:
         try:

--- a/test/services/network/translator/test_network_translator.py
+++ b/test/services/network/translator/test_network_translator.py
@@ -13,132 +13,132 @@ from services.common.translator.base_test_translator import validate_service_tra
 T = TypeVar("T", bound=IdentifiedObject)
 
 types_to_test = {
-    #######################
-    # IEC61968 ASSET INFO #
-    #######################
-
-    "create_cable_info": create_cable_info(),
-    "create_no_load_test": create_no_load_test(),
-    "create_open_circuit_test": create_open_circuit_test(),
-    "create_overhead_wire_info": create_overhead_wire_info(),
-    "create_power_transformer_info": create_power_transformer_info(),
-    "create_short_circuit_test": create_short_circuit_test(),
-    "create_shunt_compensator_info": create_shunt_compensator_info(),
-    "create_transformer_end_info": create_transformer_end_info(),
-    "create_transformer_tank_info": create_transformer_tank_info(),
-
-    ###################
-    # IEC61968 ASSETS #
-    ###################
-
-    "create_asset_owner": create_asset_owner(),
-    "create_pole": create_pole(),
-    "create_streetlight": create_streetlight(),
-
-    ###################
-    # IEC61968 COMMON #
-    ###################
-
-    # NOTE: location is tested separately due to constraints on the translation.
-    # "create_location": create_location(),
-    "create_organisation": create_organisation(),
-
-    #####################
-    # IEC61968 METERING #
-    #####################
-
-    "create_meter": create_meter(),
-    "create_usage_point": create_usage_point(),
-
-    #######################
-    # IEC61968 OPERATIONS #
-    #######################
-
-    "create_operational_restriction": create_operational_restriction(),
-
-    #####################################
-    # IEC61970 BASE AUXILIARY EQUIPMENT #
-    #####################################
-
-    "create_fault_indicator": create_fault_indicator(),
-
-    ######################
-    # IEC61970 BASE CORE #
-    ######################
-
-    "create_base_voltage": create_base_voltage(),
-    "create_connectivity_node": create_connectivity_node(),
-    "create_feeder": create_feeder(),
-    "create_geographical_region": create_geographical_region(),
-    "create_site": create_site(),
-    "create_sub_geographical_region": create_sub_geographical_region(),
-    "create_substation": create_substation(),
-    "create_terminal": create_terminal(),
-
-    #############################
-    # IEC61970 BASE EQUIVALENTS #
-    #############################
-
-    "create_equivalent_branch": create_equivalent_branch(),
-
-    ######################
-    # IEC61970 BASE MEAS #
-    ######################
-
-    "create_accumulator": create_accumulator(),
-    "create_analog": create_analog(),
-    "create_control": create_control(),
-    "create_discrete": create_discrete(),
-
-    #######################
-    # IEC61970 BASE SCADA #
-    #######################
-
-    "create_remote_control": create_remote_control(),
-    "create_remote_source": create_remote_source(),
-
-    ########################################
-    # IEC61970 WIRES GENERATION PRODUCTION #
-    ########################################
-
-    "create_battery_unit": create_battery_unit(),
-    "create_photovoltaic_unit": create_photovoltaic_unit(),
-    "create_power_electronics_wind_unit": create_power_electronics_wind_unit(),
-
-    #######################
-    # IEC61970 BASE WIRES #
-    #######################
-
-    "create_ac_line_segment": create_ac_line_segment(),
-    "create_breaker": create_breaker(),
-    "create_busbar_section": create_busbar_section(),
-    "create_disconnector": create_disconnector(),
-    "create_energy_consumer": create_energy_consumer(),
-    "create_energy_consumer_phase": create_energy_consumer_phase(),
-    "create_energy_source": create_energy_source(),
-    "create_energy_source_phase": create_energy_source_phase(),
-    "create_fuse": create_fuse(),
-    "create_jumper": create_jumper(),
-    "create_junction": create_junction(),
-
-    "create_linear_shunt_compensator": create_linear_shunt_compensator(),
-    "create_load_break_switch": create_load_break_switch(),
-    "create_per_length_sequence_impedance": create_per_length_sequence_impedance(),
-    "create_power_electronics_connection": create_power_electronics_connection(),
-    "create_power_electronics_connection_phase": create_power_electronics_connection_phase(),
+    # #######################
+    # # IEC61968 ASSET INFO #
+    # #######################
+    #
+    # "create_cable_info": create_cable_info(),
+    # "create_no_load_test": create_no_load_test(),
+    # "create_open_circuit_test": create_open_circuit_test(),
+    # "create_overhead_wire_info": create_overhead_wire_info(),
+    # "create_power_transformer_info": create_power_transformer_info(),
+    # "create_short_circuit_test": create_short_circuit_test(),
+    # "create_shunt_compensator_info": create_shunt_compensator_info(),
+    # "create_transformer_end_info": create_transformer_end_info(),
+    # "create_transformer_tank_info": create_transformer_tank_info(),
+    #
+    # ###################
+    # # IEC61968 ASSETS #
+    # ###################
+    #
+    # "create_asset_owner": create_asset_owner(),
+    # "create_pole": create_pole(),
+    # "create_streetlight": create_streetlight(),
+    #
+    # ###################
+    # # IEC61968 COMMON #
+    # ###################
+    #
+    # # NOTE: location is tested separately due to constraints on the translation.
+    # # "create_location": create_location(),
+    # "create_organisation": create_organisation(),
+    #
+    # #####################
+    # # IEC61968 METERING #
+    # #####################
+    #
+    # "create_meter": create_meter(),
+    # "create_usage_point": create_usage_point(),
+    #
+    # #######################
+    # # IEC61968 OPERATIONS #
+    # #######################
+    #
+    # "create_operational_restriction": create_operational_restriction(),
+    #
+    # #####################################
+    # # IEC61970 BASE AUXILIARY EQUIPMENT #
+    # #####################################
+    #
+    # "create_fault_indicator": create_fault_indicator(),
+    #
+    # ######################
+    # # IEC61970 BASE CORE #
+    # ######################
+    #
+    # "create_base_voltage": create_base_voltage(),
+    # "create_connectivity_node": create_connectivity_node(),
+    # "create_feeder": create_feeder(),
+    # "create_geographical_region": create_geographical_region(),
+    # "create_site": create_site(),
+    # "create_sub_geographical_region": create_sub_geographical_region(),
+    # "create_substation": create_substation(),
+    # "create_terminal": create_terminal(),
+    #
+    # #############################
+    # # IEC61970 BASE EQUIVALENTS #
+    # #############################
+    #
+    # "create_equivalent_branch": create_equivalent_branch(),
+    #
+    # ######################
+    # # IEC61970 BASE MEAS #
+    # ######################
+    #
+    # "create_accumulator": create_accumulator(),
+    # "create_analog": create_analog(),
+    # "create_control": create_control(),
+    # "create_discrete": create_discrete(),
+    #
+    # #######################
+    # # IEC61970 BASE SCADA #
+    # #######################
+    #
+    # "create_remote_control": create_remote_control(),
+    # "create_remote_source": create_remote_source(),
+    #
+    # ########################################
+    # # IEC61970 WIRES GENERATION PRODUCTION #
+    # ########################################
+    #
+    # "create_battery_unit": create_battery_unit(),
+    # "create_photovoltaic_unit": create_photovoltaic_unit(),
+    # "create_power_electronics_wind_unit": create_power_electronics_wind_unit(),
+    #
+    # #######################
+    # # IEC61970 BASE WIRES #
+    # #######################
+    #
+    # "create_ac_line_segment": create_ac_line_segment(),
+    # "create_breaker": create_breaker(),
+    # "create_busbar_section": create_busbar_section(),
+    # "create_disconnector": create_disconnector(),
+    # "create_energy_consumer": create_energy_consumer(),
+    # "create_energy_consumer_phase": create_energy_consumer_phase(),
+    # "create_energy_source": create_energy_source(),
+    # "create_energy_source_phase": create_energy_source_phase(),
+    # "create_fuse": create_fuse(),
+    # "create_jumper": create_jumper(),
+    # "create_junction": create_junction(),
+    #
+    # "create_linear_shunt_compensator": create_linear_shunt_compensator(),
+    # "create_load_break_switch": create_load_break_switch(),
+    # "create_per_length_sequence_impedance": create_per_length_sequence_impedance(),
+    # "create_power_electronics_connection": create_power_electronics_connection(),
+    # "create_power_electronics_connection_phase": create_power_electronics_connection_phase(),
     "create_power_transformer": create_power_transformer(),
     "create_power_transformer_end": create_power_transformer_end(),
-    "create_ratio_tap_changer": create_ratio_tap_changer(),
-    "create_recloser": create_recloser(),
-    "create_transformer_star_impedance": create_transformer_star_impedance(),
-
-    #########################
-    # IEC61970 INF IEC61970 #
-    #########################
-
-    "create_circuit": create_circuit(),
-    "create_loop": create_loop(),
-    "create_lv_feeder": create_lv_feeder()
+    # "create_ratio_tap_changer": create_ratio_tap_changer(),
+    # "create_recloser": create_recloser(),
+    # "create_transformer_star_impedance": create_transformer_star_impedance(),
+    #
+    # #########################
+    # # IEC61970 INF IEC61970 #
+    # #########################
+    #
+    # "create_circuit": create_circuit(),
+    # "create_loop": create_loop(),
+    # "create_lv_feeder": create_lv_feeder()
 }
 
 
@@ -185,3 +185,16 @@ def test_updates_existing_name_type():
 
     assert cim is nt
     assert cim.description == pb.description
+
+
+def test_power_transformer_end_order():
+    e1 = PowerTransformerEnd(mrid="e1", end_number=1)
+    e2 = PowerTransformerEnd(mrid="e2", end_number=2)
+    tx = PowerTransformer(mrid="tx", power_transformer_ends=[e1, e2])
+
+    ns = NetworkService()
+    ns.add_from_pb(tx.to_pb())
+    ns.add_from_pb(e2.to_pb())
+    ns.add_from_pb(e1.to_pb())
+
+    assert [end.mrid for end in ns["tx"].ends] == ["e1", "e2"]

--- a/test/services/network/translator/test_network_translator.py
+++ b/test/services/network/translator/test_network_translator.py
@@ -13,132 +13,132 @@ from services.common.translator.base_test_translator import validate_service_tra
 T = TypeVar("T", bound=IdentifiedObject)
 
 types_to_test = {
-    # #######################
-    # # IEC61968 ASSET INFO #
-    # #######################
-    #
-    # "create_cable_info": create_cable_info(),
-    # "create_no_load_test": create_no_load_test(),
-    # "create_open_circuit_test": create_open_circuit_test(),
-    # "create_overhead_wire_info": create_overhead_wire_info(),
-    # "create_power_transformer_info": create_power_transformer_info(),
-    # "create_short_circuit_test": create_short_circuit_test(),
-    # "create_shunt_compensator_info": create_shunt_compensator_info(),
-    # "create_transformer_end_info": create_transformer_end_info(),
-    # "create_transformer_tank_info": create_transformer_tank_info(),
-    #
-    # ###################
-    # # IEC61968 ASSETS #
-    # ###################
-    #
-    # "create_asset_owner": create_asset_owner(),
-    # "create_pole": create_pole(),
-    # "create_streetlight": create_streetlight(),
-    #
-    # ###################
-    # # IEC61968 COMMON #
-    # ###################
-    #
-    # # NOTE: location is tested separately due to constraints on the translation.
-    # # "create_location": create_location(),
-    # "create_organisation": create_organisation(),
-    #
-    # #####################
-    # # IEC61968 METERING #
-    # #####################
-    #
-    # "create_meter": create_meter(),
-    # "create_usage_point": create_usage_point(),
-    #
-    # #######################
-    # # IEC61968 OPERATIONS #
-    # #######################
-    #
-    # "create_operational_restriction": create_operational_restriction(),
-    #
-    # #####################################
-    # # IEC61970 BASE AUXILIARY EQUIPMENT #
-    # #####################################
-    #
-    # "create_fault_indicator": create_fault_indicator(),
-    #
-    # ######################
-    # # IEC61970 BASE CORE #
-    # ######################
-    #
-    # "create_base_voltage": create_base_voltage(),
-    # "create_connectivity_node": create_connectivity_node(),
-    # "create_feeder": create_feeder(),
-    # "create_geographical_region": create_geographical_region(),
-    # "create_site": create_site(),
-    # "create_sub_geographical_region": create_sub_geographical_region(),
-    # "create_substation": create_substation(),
-    # "create_terminal": create_terminal(),
-    #
-    # #############################
-    # # IEC61970 BASE EQUIVALENTS #
-    # #############################
-    #
-    # "create_equivalent_branch": create_equivalent_branch(),
-    #
-    # ######################
-    # # IEC61970 BASE MEAS #
-    # ######################
-    #
-    # "create_accumulator": create_accumulator(),
-    # "create_analog": create_analog(),
-    # "create_control": create_control(),
-    # "create_discrete": create_discrete(),
-    #
-    # #######################
-    # # IEC61970 BASE SCADA #
-    # #######################
-    #
-    # "create_remote_control": create_remote_control(),
-    # "create_remote_source": create_remote_source(),
-    #
-    # ########################################
-    # # IEC61970 WIRES GENERATION PRODUCTION #
-    # ########################################
-    #
-    # "create_battery_unit": create_battery_unit(),
-    # "create_photovoltaic_unit": create_photovoltaic_unit(),
-    # "create_power_electronics_wind_unit": create_power_electronics_wind_unit(),
-    #
-    # #######################
-    # # IEC61970 BASE WIRES #
-    # #######################
-    #
-    # "create_ac_line_segment": create_ac_line_segment(),
-    # "create_breaker": create_breaker(),
-    # "create_busbar_section": create_busbar_section(),
-    # "create_disconnector": create_disconnector(),
-    # "create_energy_consumer": create_energy_consumer(),
-    # "create_energy_consumer_phase": create_energy_consumer_phase(),
-    # "create_energy_source": create_energy_source(),
-    # "create_energy_source_phase": create_energy_source_phase(),
-    # "create_fuse": create_fuse(),
-    # "create_jumper": create_jumper(),
-    # "create_junction": create_junction(),
-    #
-    # "create_linear_shunt_compensator": create_linear_shunt_compensator(),
-    # "create_load_break_switch": create_load_break_switch(),
-    # "create_per_length_sequence_impedance": create_per_length_sequence_impedance(),
-    # "create_power_electronics_connection": create_power_electronics_connection(),
-    # "create_power_electronics_connection_phase": create_power_electronics_connection_phase(),
+    #######################
+    # IEC61968 ASSET INFO #
+    #######################
+
+    "create_cable_info": create_cable_info(),
+    "create_no_load_test": create_no_load_test(),
+    "create_open_circuit_test": create_open_circuit_test(),
+    "create_overhead_wire_info": create_overhead_wire_info(),
+    "create_power_transformer_info": create_power_transformer_info(),
+    "create_short_circuit_test": create_short_circuit_test(),
+    "create_shunt_compensator_info": create_shunt_compensator_info(),
+    "create_transformer_end_info": create_transformer_end_info(),
+    "create_transformer_tank_info": create_transformer_tank_info(),
+
+    ###################
+    # IEC61968 ASSETS #
+    ###################
+
+    "create_asset_owner": create_asset_owner(),
+    "create_pole": create_pole(),
+    "create_streetlight": create_streetlight(),
+
+    ###################
+    # IEC61968 COMMON #
+    ###################
+
+    # NOTE: location is tested separately due to constraints on the translation.
+    # "create_location": create_location(),
+    "create_organisation": create_organisation(),
+
+    #####################
+    # IEC61968 METERING #
+    #####################
+
+    "create_meter": create_meter(),
+    "create_usage_point": create_usage_point(),
+
+    #######################
+    # IEC61968 OPERATIONS #
+    #######################
+
+    "create_operational_restriction": create_operational_restriction(),
+
+    #####################################
+    # IEC61970 BASE AUXILIARY EQUIPMENT #
+    #####################################
+
+    "create_fault_indicator": create_fault_indicator(),
+
+    ######################
+    # IEC61970 BASE CORE #
+    ######################
+
+    "create_base_voltage": create_base_voltage(),
+    "create_connectivity_node": create_connectivity_node(),
+    "create_feeder": create_feeder(),
+    "create_geographical_region": create_geographical_region(),
+    "create_site": create_site(),
+    "create_sub_geographical_region": create_sub_geographical_region(),
+    "create_substation": create_substation(),
+    "create_terminal": create_terminal(),
+
+    #############################
+    # IEC61970 BASE EQUIVALENTS #
+    #############################
+
+    "create_equivalent_branch": create_equivalent_branch(),
+
+    ######################
+    # IEC61970 BASE MEAS #
+    ######################
+
+    "create_accumulator": create_accumulator(),
+    "create_analog": create_analog(),
+    "create_control": create_control(),
+    "create_discrete": create_discrete(),
+
+    #######################
+    # IEC61970 BASE SCADA #
+    #######################
+
+    "create_remote_control": create_remote_control(),
+    "create_remote_source": create_remote_source(),
+
+    ########################################
+    # IEC61970 WIRES GENERATION PRODUCTION #
+    ########################################
+
+    "create_battery_unit": create_battery_unit(),
+    "create_photovoltaic_unit": create_photovoltaic_unit(),
+    "create_power_electronics_wind_unit": create_power_electronics_wind_unit(),
+
+    #######################
+    # IEC61970 BASE WIRES #
+    #######################
+
+    "create_ac_line_segment": create_ac_line_segment(),
+    "create_breaker": create_breaker(),
+    "create_busbar_section": create_busbar_section(),
+    "create_disconnector": create_disconnector(),
+    "create_energy_consumer": create_energy_consumer(),
+    "create_energy_consumer_phase": create_energy_consumer_phase(),
+    "create_energy_source": create_energy_source(),
+    "create_energy_source_phase": create_energy_source_phase(),
+    "create_fuse": create_fuse(),
+    "create_jumper": create_jumper(),
+    "create_junction": create_junction(),
+
+    "create_linear_shunt_compensator": create_linear_shunt_compensator(),
+    "create_load_break_switch": create_load_break_switch(),
+    "create_per_length_sequence_impedance": create_per_length_sequence_impedance(),
+    "create_power_electronics_connection": create_power_electronics_connection(),
+    "create_power_electronics_connection_phase": create_power_electronics_connection_phase(),
     "create_power_transformer": create_power_transformer(),
     "create_power_transformer_end": create_power_transformer_end(),
-    # "create_ratio_tap_changer": create_ratio_tap_changer(),
-    # "create_recloser": create_recloser(),
-    # "create_transformer_star_impedance": create_transformer_star_impedance(),
-    #
-    # #########################
-    # # IEC61970 INF IEC61970 #
-    # #########################
-    #
-    # "create_circuit": create_circuit(),
-    # "create_loop": create_loop(),
-    # "create_lv_feeder": create_lv_feeder()
+    "create_ratio_tap_changer": create_ratio_tap_changer(),
+    "create_recloser": create_recloser(),
+    "create_transformer_star_impedance": create_transformer_star_impedance(),
+
+    #########################
+    # IEC61970 INF IEC61970 #
+    #########################
+
+    "create_circuit": create_circuit(),
+    "create_loop": create_loop(),
+    "create_lv_feeder": create_lv_feeder()
 }
 
 


### PR DESCRIPTION
Signed-off-by: Marcus Koh <marcus.koh@zepben.com>

# Description

Ensures correct order of transformer ends in `tx.ends`, where `tx` is a `PowerTransformer` translated from protobuf. See https://app.clickup.com/t/369vbur for more details.

# Associated tasks:

Tasks blocking this one:
- None

Tasks this is blocking:
- https://github.com/zepben/edith-sdk/pull/2

# Checklist:

- [x] I have performed a self review of my own code.
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have updated the changelog.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
