### PR TITLE
EWB-2540: Add missing licence

### DIFF
--- a/src/zepben/evolve/model/cim/iec61970/base/auxiliaryequipment/potential_transformer_kind.py
+++ b/src/zepben/evolve/model/cim/iec61970/base/auxiliaryequipment/potential_transformer_kind.py
@@ -1,3 +1,8 @@
+#  Copyright 2022 Zeppelin Bend Pty Ltd
+#
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from enum import Enum
 
 __all__ = ["PotentialTransformerKind"]


### PR DESCRIPTION
Signed-off-by: Marcus Koh <marcus.koh@zepben.com>

# Description

Adds missing licence header comment to `potential_transformer_kind.py`.

# Associated tasks:

Tasks blocking this one:
- None

Tasks this is blocking:
- None (licence check is being skipped on other branches)

# Checklist:

- [x] I have performed a self review of my own code.
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
