### PR TITLE
Add missing methods to __all__ in tracing.py

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -54,6 +54,7 @@
 * Added missing `run` method for `DownstreamTree`.
 * Added missing `TreeNodeTracker`.
 * Classes in the `zepben.evolve.services.network.tracing.tree.*` submodules may now be imported `from zepben.evolve`.
+* Add `normal_upstream_trace`, `current_upstream_trace`, and `phase_inferrer` to `__all__` in `zepben.evolve.services.network.tracing.tracing`.
 
 ### Notes
 * None.

--- a/src/zepben/evolve/services/network/tracing/tracing.py
+++ b/src/zepben/evolve/services/network/tracing/tracing.py
@@ -34,10 +34,10 @@ if TYPE_CHECKING:
 
 __all__ = ["create_basic_depth_trace", "create_basic_breadth_trace", "connected_equipment_trace", "connected_equipment_breadth_trace",
            "normal_connected_equipment_trace", "current_connected_equipment_trace", "normal_limited_connected_equipment_trace",
-           "current_limited_connected_equipment_trace", "phase_trace", "normal_phase_trace", "current_phase_trace", "connectivity_trace",
-           "connectivity_breadth_trace", "normal_connectivity_trace", "current_connectivity_trace", "normal_downstream_trace", "current_downstream_trace",
-           "set_phases", "remove_phases", "set_direction", "remove_direction", "assign_equipment_to_feeders", "assign_equipment_to_lv_feeders",
-           "find_swer_equipment"]
+           "current_limited_connected_equipment_trace", "connectivity_trace", "connectivity_breadth_trace", "normal_connectivity_trace",
+           "current_connectivity_trace", "phase_trace", "normal_phase_trace", "current_phase_trace", "normal_downstream_trace", "current_downstream_trace",
+           "normal_upstream_trace", "current_upstream_trace", "normal_downstream_tree", "current_downstream_tree", "set_phases", "remove_phases",
+           "set_direction", "remove_direction", "phase_inferrer", "assign_equipment_to_feeders", "assign_equipment_to_lv_feeders", "find_swer_equipment"]
 
 
 # --- Helper functions that create depth-first/breadth-first traversals ---

--- a/test/services/network/tracing/test_tracing.py
+++ b/test/services/network/tracing/test_tracing.py
@@ -8,8 +8,13 @@ from typing import Type, Callable, TypeVar
 import pytest
 
 from zepben.evolve import BasicTraversal, SetPhases, RemovePhases, AssignToFeeders, Breaker, Terminal, PhaseCode, ConductingEquipment, \
-    connected_equipment_trace, SetDirection, RemoveDirection, ConductingEquipmentStep, AssignToLvFeeders, FindSwerEquipment, NetworkService
-from zepben.evolve.services.network.tracing import tracing
+    connected_equipment_trace, SetDirection, RemoveDirection, ConductingEquipmentStep, AssignToLvFeeders, FindSwerEquipment, NetworkService, \
+    normal_connected_equipment_trace, current_connected_equipment_trace, phase_trace, normal_phase_trace, current_phase_trace, normal_downstream_trace, \
+    current_downstream_trace, normal_upstream_trace, current_upstream_trace, set_phases, remove_phases, create_basic_breadth_trace, create_basic_depth_trace, \
+    normal_downstream_tree, assign_equipment_to_lv_feeders, assign_equipment_to_feeders, current_downstream_tree, find_swer_equipment, \
+    connected_equipment_breadth_trace, normal_limited_connected_equipment_trace, LimitedConnectedEquipmentTrace, current_limited_connected_equipment_trace, \
+    remove_direction, set_direction, connectivity_trace, connectivity_breadth_trace, normal_connectivity_trace, current_connectivity_trace, phase_inferrer, \
+    PhaseInferrer
 from zepben.evolve.services.network.tracing.phases import phase_step
 from zepben.evolve.services.network.tracing.tree.downstream_tree import DownstreamTree
 
@@ -37,32 +42,48 @@ async def test_basic_asset_trace(phase_swap_loop_network: NetworkService):
 
 
 def test_suppliers():
-    _validate_supplier(lambda: tracing.create_basic_depth_trace(lambda i, t: None), BasicTraversal)
-    _validate_supplier(lambda: tracing.create_basic_breadth_trace(lambda i, t: None), BasicTraversal)
-    _validate_supplier(tracing.connected_equipment_trace, BasicTraversal)
-    _validate_supplier(tracing.normal_connected_equipment_trace, BasicTraversal)
-    _validate_supplier(tracing.current_connected_equipment_trace, BasicTraversal)
-    _validate_supplier(tracing.phase_trace, BasicTraversal)
-    _validate_supplier(tracing.normal_phase_trace, BasicTraversal)
-    _validate_supplier(tracing.current_phase_trace, BasicTraversal)
-    _validate_supplier(tracing.normal_downstream_trace, BasicTraversal)
-    _validate_supplier(tracing.current_downstream_trace, BasicTraversal)
-    _validate_supplier(tracing.normal_upstream_trace, BasicTraversal)
-    _validate_supplier(tracing.current_upstream_trace, BasicTraversal)
-    _validate_supplier(tracing.set_phases, SetPhases)
-    _validate_supplier(tracing.remove_phases, RemovePhases)
+    _validate_supplier(lambda: create_basic_depth_trace(lambda i, t: None), BasicTraversal)
+    _validate_supplier(lambda: create_basic_breadth_trace(lambda i, t: None), BasicTraversal)
 
-    _validate_supplier(tracing.set_direction, SetDirection)
-    _validate_supplier(tracing.remove_direction, RemoveDirection)
+    _validate_supplier(connected_equipment_trace, BasicTraversal)
+    _validate_supplier(connected_equipment_breadth_trace, BasicTraversal)
+    _validate_supplier(normal_connected_equipment_trace, BasicTraversal)
+    _validate_supplier(current_connected_equipment_trace, BasicTraversal)
 
-    _validate_supplier(tracing.assign_equipment_to_feeders, AssignToFeeders)
-    _validate_supplier(tracing.assign_equipment_to_lv_feeders, AssignToLvFeeders)
-    _validate_supplier(tracing.normal_downstream_tree, DownstreamTree)
-    _validate_supplier(tracing.normal_downstream_tree, DownstreamTree)
+    _validate_supplier(normal_limited_connected_equipment_trace, LimitedConnectedEquipmentTrace)
+    _validate_supplier(current_limited_connected_equipment_trace, LimitedConnectedEquipmentTrace)
+
+    _validate_supplier(connectivity_trace, BasicTraversal)
+    _validate_supplier(connectivity_breadth_trace, BasicTraversal)
+    _validate_supplier(normal_connectivity_trace, BasicTraversal)
+    _validate_supplier(current_connectivity_trace, BasicTraversal)
+
+    _validate_supplier(phase_trace, BasicTraversal)
+    _validate_supplier(normal_phase_trace, BasicTraversal)
+    _validate_supplier(current_phase_trace, BasicTraversal)
+
+    _validate_supplier(normal_downstream_trace, BasicTraversal)
+    _validate_supplier(current_downstream_trace, BasicTraversal)
+    _validate_supplier(normal_upstream_trace, BasicTraversal)
+    _validate_supplier(current_upstream_trace, BasicTraversal)
+
+    _validate_supplier(normal_downstream_tree, DownstreamTree)
+    _validate_supplier(current_downstream_tree, DownstreamTree)
+
+    _validate_supplier(set_phases, SetPhases)
+    _validate_supplier(remove_phases, RemovePhases)
+
+    _validate_supplier(set_direction, SetDirection)
+    _validate_supplier(remove_direction, RemoveDirection)
+
+    _validate_supplier(phase_inferrer, PhaseInferrer)
+
+    _validate_supplier(assign_equipment_to_feeders, AssignToFeeders)
+    _validate_supplier(assign_equipment_to_lv_feeders, AssignToLvFeeders)
 
     # TODO: EWB-2596
-    # _validate_supplier(tracing.find_with_usage_points, FindWithUsagePoints)
-    _validate_supplier(tracing.find_swer_equipment, FindSwerEquipment)
+    # _validate_supplier(find_with_usage_points, FindWithUsagePoints)
+    _validate_supplier(find_swer_equipment, FindSwerEquipment)
 
 
 @pytest.mark.asyncio
@@ -73,7 +94,7 @@ async def test_downstream_trace_with_too_many_phases():
     b1 = Breaker()
     b1.add_terminal(t)
 
-    await tracing.normal_downstream_trace().run(phase_step.start_at(b1, PhaseCode.ABCN))
+    await normal_downstream_trace().run(phase_step.start_at(b1, PhaseCode.ABCN))
 
 
 def _validate_supplier(supplier: Callable[[], T], expected_class: Type):

--- a/test/services/network/tracing/tree/test_downstream_tree.py
+++ b/test/services/network/tracing/tree/test_downstream_tree.py
@@ -9,8 +9,7 @@ from typing import Optional, List
 import pytest
 
 from services.network.test_data.looping_network import create_looping_network
-from zepben.evolve import set_phases, ConductingEquipment, set_direction, TreeNode
-from zepben.evolve.services.network.tracing.tracing import normal_downstream_tree
+from zepben.evolve import set_phases, ConductingEquipment, set_direction, TreeNode, normal_downstream_tree
 
 
 @pytest.mark.asyncio

--- a/test/services/network/tracing/tree/test_tree_node_tracker.py
+++ b/test/services/network/tracing/tree/test_tree_node_tracker.py
@@ -3,9 +3,7 @@
 #  This Source Code Form is subject to the terms of the Mozilla Public
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
-from zepben.evolve import Breaker
-from zepben.evolve.services.network.tracing.tree.tree_node import TreeNode
-from zepben.evolve.services.network.tracing.tree.tree_node_tracker import TreeNodeTracker
+from zepben.evolve import Breaker, TreeNode, TreeNodeTracker
 
 
 def test_single_tree_node_and_clear():


### PR DESCRIPTION
Signed-off-by: Marcus Koh <marcus.koh@zepben.com>

# Description

Adds method names currently missing from `__all__` in `tracing.py`. Also updates test to include all public methods in `test_suppliers()`.

# Associated tasks:

Tasks blocking this one:
 - None

Tasks this is blocking:
 - https://github.com/zepben/edith-sdk/pull/3
 - https://github.com/zepben/pp-translator/pull/19

# Checklist:

- [x] I have performed a self review of my own code.
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have updated the changelog.
