### PR TITLE
EWB-2592: Fix downstream trees

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -36,6 +36,10 @@
 ### Enhancements
 * `tracker` is now a field in `Traversal`, rather than its subclasses.
 * The constructor for `BranchRecursiveTraversal` now defaults the `process_queue` field to `depth_first()`.
+* `TreeNode` is now more closely aligned with its Kotlin version:
+  * `TreeNode().parent` is now a read-only property.
+  * `TreeNode().children` has been added as a read-only property that yields each child node.
+  * `TreeNode().sort_weight` has been added as a read-only property that returns the sort weight of the node.
 
 ### Fixes
 * `StreetDetail.to_cim` now references the protobuf -> CIM translation function for the `StreetDetail` protobuf type.
@@ -48,6 +52,7 @@
 * Add `normal_upstream_trace`, `current_upstream_trace`, and `phase_inferrer` to `__all__` in `zepben.evolve.services.network.tracing.tracing`.
 * Added missing `run` method for `DownstreamTree`.
 * Added missing `TreeNodeTracker`.
+* Classes in the `zepben.evolve.services.network.tracing.tree.*` submodules may now be imported `from zepben.evolve`.
 
 ### Notes
 * None.

--- a/changelog.md
+++ b/changelog.md
@@ -44,6 +44,8 @@
 * Fixed bug where running a limited connected equipment trace with `maximum_steps=1`
   included equipment two steps away from the starting equipment if `feeder_direction` is set.
 * Each stop condition of a traversal is now checked on each step, regardless if a previous one in the internal list has returned `True`.
+* Add `normal_upstream_trace`, `current_upstream_trace`, and `phase_inferrer` to `__all__` in `zepben.evolve.services.network.tracing.tracing`.
+* Added missing `run` method for `DownstreamTree`.
 
 ### Notes
 * None.

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@
     when fetching the authentication config and requesting access tokens respectively.
   * `ca` is replaced with `ca_filename`, which can be set to the filename of a CA to use when verifying the certificate
     of the gRPC service.
+* Refactored `TreeNode` class to its own submodule: `zepben.evolve.services.network.tracing.tree.tree_node`.
 
 ### New Features
 * Added support for current transformers and power transformers with the following classes in `zepben.evolve.cim.*`:

--- a/changelog.md
+++ b/changelog.md
@@ -40,6 +40,7 @@
   * `TreeNode().parent` is now a read-only property.
   * `TreeNode().children` has been added as a read-only property that yields each child node.
   * `TreeNode().sort_weight` has been added as a read-only property that returns the sort weight of the node.
+* All `Tracker` classes can now be copied using the `copy` method.
 
 ### Fixes
 * `StreetDetail.to_cim` now references the protobuf -> CIM translation function for the `StreetDetail` protobuf type.

--- a/changelog.md
+++ b/changelog.md
@@ -46,6 +46,7 @@
 * Each stop condition of a traversal is now checked on each step, regardless if a previous one in the internal list has returned `True`.
 * Add `normal_upstream_trace`, `current_upstream_trace`, and `phase_inferrer` to `__all__` in `zepben.evolve.services.network.tracing.tracing`.
 * Added missing `run` method for `DownstreamTree`.
+* Added missing `TreeNodeTracker`.
 
 ### Notes
 * None.

--- a/src/zepben/evolve/__init__.py
+++ b/src/zepben/evolve/__init__.py
@@ -134,6 +134,9 @@ from zepben.evolve.services.network.tracing.phases.phase_trace import *
 from zepben.evolve.services.network.tracing.phases.set_phases import *
 from zepben.evolve.services.network.tracing.phases.phase_inferrer import *
 from zepben.evolve.services.network.tracing.phases.remove_phases import *
+from zepben.evolve.services.network.tracing.tree.downstream_tree import *
+from zepben.evolve.services.network.tracing.tree.tree_node import *
+from zepben.evolve.services.network.tracing.tree.tree_node_tracker import *
 from zepben.evolve.services.network.tracing.find import *
 from zepben.evolve.services.network.tracing.find_swer_equipment import *
 from zepben.evolve.services.network.tracing.tracing import *

--- a/src/zepben/evolve/services/network/tracing/connectivity/conducting_equipment_step_tracker.py
+++ b/src/zepben/evolve/services/network/tracing/connectivity/conducting_equipment_step_tracker.py
@@ -3,6 +3,8 @@
 #  This Source Code Form is subject to the terms of the Mozilla Public
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from __future__ import annotations
+
 from typing import Dict
 
 from zepben.evolve import Tracker, ConductingEquipmentStep, ConductingEquipment
@@ -49,3 +51,7 @@ class ConductingEquipmentStepTracker(Tracker[ConductingEquipmentStep]):
         Clear the tracker, removing all visited items.
         """
         self._minimum_steps = {}
+
+    def copy(self) -> ConductingEquipmentStepTracker:
+        # noinspection PyArgumentList
+        return ConductingEquipmentStepTracker(_minimum_steps=self._minimum_steps.copy())

--- a/src/zepben/evolve/services/network/tracing/connectivity/connectivity_tracker.py
+++ b/src/zepben/evolve/services/network/tracing/connectivity/connectivity_tracker.py
@@ -34,3 +34,7 @@ class ConnectivityTracker(Tracker[ConnectivityResult]):
 
     def clear(self):
         self._visited.clear()
+
+    def copy(self) -> ConnectivityTracker:
+        # noinspection PyArgumentList
+        return ConnectivityTracker(_visited=self._visited.copy())

--- a/src/zepben/evolve/services/network/tracing/feeder/associated_terminal_tracker.py
+++ b/src/zepben/evolve/services/network/tracing/feeder/associated_terminal_tracker.py
@@ -19,16 +19,16 @@ class AssociatedTerminalTracker(BasicTracker[Optional[Terminal]]):
         # Any terminal that does not have a valid conducting equipment reference is considered visited.
         if terminal is not None:
             if terminal.conducting_equipment is not None:
-                return terminal.conducting_equipment in self.visited
+                return terminal.conducting_equipment in self._visited
         return True
 
     def visit(self, terminal: Optional[Terminal]) -> bool:
         # We don't visit any terminal that does not have a valid conducting equipment reference.
         if terminal is not None:
             if terminal.conducting_equipment is not None:
-                if terminal.conducting_equipment in self.visited:
+                if terminal.conducting_equipment in self._visited:
                     return False
 
-                self.visited.add(terminal.conducting_equipment)
+                self._visited.add(terminal.conducting_equipment)
                 return True
         return False

--- a/src/zepben/evolve/services/network/tracing/phases/phase_step_tracker.py
+++ b/src/zepben/evolve/services/network/tracing/phases/phase_step_tracker.py
@@ -28,13 +28,13 @@ class PhaseStepTracker(Tracker[PhaseStep]):
     This tracker does not support null items.
     """
 
-    visited: Dict[ConductingEquipment, Set[SinglePhaseKind]] = defaultdict(set)
+    _visited: Dict[ConductingEquipment, Set[SinglePhaseKind]] = defaultdict(set)
 
     def has_visited(self, item: PhaseStep) -> bool:
-        return item.phases.issubset(self.visited[item.conducting_equipment])
+        return item.phases.issubset(self._visited[item.conducting_equipment])
 
     def visit(self, item: PhaseStep) -> bool:
-        visited_phases = self.visited[item.conducting_equipment]
+        visited_phases = self._visited[item.conducting_equipment]
 
         changed = False
         for phase in item.phases:
@@ -44,4 +44,4 @@ class PhaseStepTracker(Tracker[PhaseStep]):
         return changed
 
     def clear(self):
-        self.visited.clear()
+        self._visited.clear()

--- a/src/zepben/evolve/services/network/tracing/phases/phase_step_tracker.py
+++ b/src/zepben/evolve/services/network/tracing/phases/phase_step_tracker.py
@@ -45,3 +45,7 @@ class PhaseStepTracker(Tracker[PhaseStep]):
 
     def clear(self):
         self._visited.clear()
+
+    def copy(self) -> PhaseStepTracker:
+        # noinspection PyArgumentList
+        return PhaseStepTracker(_visited={ce: visited_phases.copy() for ce, visited_phases in self._visited.items()})

--- a/src/zepben/evolve/services/network/tracing/phases/phase_step_tracker.py
+++ b/src/zepben/evolve/services/network/tracing/phases/phase_step_tracker.py
@@ -48,4 +48,4 @@ class PhaseStepTracker(Tracker[PhaseStep]):
 
     def copy(self) -> PhaseStepTracker:
         # noinspection PyArgumentList
-        return PhaseStepTracker(_visited={ce: visited_phases.copy() for ce, visited_phases in self._visited.items()})
+        return PhaseStepTracker(_visited=defaultdict(set, {ce: visited_phases.copy() for ce, visited_phases in self._visited.items()}))

--- a/src/zepben/evolve/services/network/tracing/traversals/basic_tracker.py
+++ b/src/zepben/evolve/services/network/tracing/traversals/basic_tracker.py
@@ -3,6 +3,7 @@
 #  This Source Code Form is subject to the terms of the Mozilla Public
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from __future__ import annotations
 
 __all__ = ["BasicTracker"]
 
@@ -17,7 +18,7 @@ class BasicTracker(Tracker[T]):
     """
     An interface used by `Traversal`'s to 'track' items that have been visited.
     """
-    visited: Set = set()
+    _visited: Set = set()
 
     def has_visited(self, item: T) -> bool:
         """
@@ -25,7 +26,7 @@ class BasicTracker(Tracker[T]):
         `item` The item to check if it has been visited.
         Returns true if the item has been visited, otherwise false.
         """
-        return item in self.visited
+        return item in self._visited
 
     def visit(self, item: T) -> bool:
         """
@@ -33,21 +34,21 @@ class BasicTracker(Tracker[T]):
         `item` The item to visit.
         Returns True if visit succeeds. False otherwise.
         """
-        if item in self.visited:
+        if item in self._visited:
             return False
         else:
-            self.visited.add(item)
+            self._visited.add(item)
             return True
 
     def clear(self):
         """
         Clear the tracker, removing all visited items.
         """
-        self.visited.clear()
+        self._visited.clear()
 
-    def copy(self):
+    def copy(self) -> BasicTracker[T]:
         """
         Create a new `BasicTracker` with the same visited items. Does not other class members. e.g. queue, step actions or stop conditions etc.
         """
         # noinspection PyArgumentList
-        return BasicTracker(visited=self.visited.copy())
+        return BasicTracker(_visited=self._visited.copy())

--- a/src/zepben/evolve/services/network/tracing/traversals/tracker.py
+++ b/src/zepben/evolve/services/network/tracing/traversals/tracker.py
@@ -3,6 +3,7 @@
 #  This Source Code Form is subject to the terms of the Mozilla Public
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from __future__ import annotations
 
 from abc import abstractmethod
 
@@ -44,5 +45,14 @@ class Tracker(Generic[T]):
     def clear(self):
         """
         Clear the tracker, removing all visited items.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def copy(self) -> Tracker[T]:
+        """
+        Create a copy of this tracker. `has_visited` should report the same for the copied tracker for each item,
+        but visiting an item on one of either the copy or original should not make the other report it as visited.
+        Returns the copied tracker.
         """
         raise NotImplementedError()

--- a/src/zepben/evolve/services/network/tracing/tree/downstream_tree.py
+++ b/src/zepben/evolve/services/network/tracing/tree/downstream_tree.py
@@ -55,6 +55,11 @@ class DownstreamTree(object):
                                                    process_queue=PriorityQueue(),
                                                    branch_queue=PriorityQueue())
 
+    def run(self, start: ConductingEquipment) -> TreeNode:
+        root = TreeNode(start, None)
+        self._traversal.run(root)
+        return root
+
     def _add_and_queue_next(self, current: Optional[TreeNode], traversal: BranchRecursiveTraversal[TreeNode]):
         # Loop through each of the terminals on the current conducting equipment
         if current is None:

--- a/src/zepben/evolve/services/network/tracing/tree/downstream_tree.py
+++ b/src/zepben/evolve/services/network/tracing/tree/downstream_tree.py
@@ -58,9 +58,9 @@ class DownstreamTree(object):
                                                    branch_queue=PriorityQueue(),
                                                    tracker=TreeNodeTracker())
 
-    def run(self, start: ConductingEquipment) -> TreeNode:
+    async def run(self, start: ConductingEquipment) -> TreeNode:
         root = TreeNode(start, None)
-        self._traversal.run(root)
+        await self._traversal.run(root)
         return root
 
     def _add_and_queue_next(self, current: Optional[TreeNode], traversal: BranchRecursiveTraversal[TreeNode]):

--- a/src/zepben/evolve/services/network/tracing/tree/downstream_tree.py
+++ b/src/zepben/evolve/services/network/tracing/tree/downstream_tree.py
@@ -12,6 +12,7 @@ from zepben.evolve.exceptions import TracingException
 from zepben.evolve.services.network.tracing.feeder.feeder_direction import FeederDirection
 from zepben.evolve.services.network.tracing.traversals.queue import PriorityQueue
 from zepben.evolve.services.network.tracing.traversals.branch_recursive_tracing import BranchRecursiveTraversal
+from zepben.evolve.services.network.tracing.tree.tree_node_tracker import TreeNodeTracker
 if TYPE_CHECKING:
     from zepben.evolve import ConductingEquipment, Terminal, SinglePhaseKind
     from zepben.evolve.types import OpenTest, DirectionSelector
@@ -53,7 +54,8 @@ class DownstreamTree(object):
         # noinspection PyArgumentList
         self._traversal = BranchRecursiveTraversal(queue_next=self._add_and_queue_next,
                                                    process_queue=PriorityQueue(),
-                                                   branch_queue=PriorityQueue())
+                                                   branch_queue=PriorityQueue(),
+                                                   tracker=TreeNodeTracker())
 
     def run(self, start: ConductingEquipment) -> TreeNode:
         root = TreeNode(start, None)

--- a/src/zepben/evolve/services/network/tracing/tree/tree_node.py
+++ b/src/zepben/evolve/services/network/tracing/tree/tree_node.py
@@ -1,0 +1,37 @@
+#  Copyright 2022 Zeppelin Bend Pty Ltd
+#
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from __future__ import annotations
+
+from typing import Optional, List
+
+from zepben.evolve import ConductingEquipment
+
+__all__ = ["TreeNode"]
+
+
+class TreeNode(object):
+
+    def __init__(self, conducting_equipment: ConductingEquipment, parent: Optional[TreeNode]):
+        self.conducting_equipment = conducting_equipment
+        self.parent = parent
+        self._children: List[TreeNode] = []
+        self._sort_weight = max((len(term.phases.single_phases) for term in conducting_equipment.terminals), default=1)
+
+    def __lt__(self, other: TreeNode):
+        """
+        This definition should only be used for sorting within a `PriorityQueue`
+
+        @param other: Another PhaseStep to compare against
+        @return: True if this node's max phase count over its equipment's terminals is greater than the other's, False otherwise.
+        """
+        return self._sort_weight > other._sort_weight
+
+    def __str__(self):
+        return f"{{conducting_equipment: {self.conducting_equipment.mrid}, parent: {self.parent and self.parent.conducting_equipment.mrid}, " \
+               f"num children: {len(self._children)}}}"
+
+    def add_child(self, child: TreeNode):
+        self._children.append(child)

--- a/src/zepben/evolve/services/network/tracing/tree/tree_node.py
+++ b/src/zepben/evolve/services/network/tracing/tree/tree_node.py
@@ -5,9 +5,10 @@
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
-from typing import Optional, List
+from typing import Optional, List, Generator
 
 from zepben.evolve import ConductingEquipment
+from zepben.evolve.util import ngen
 
 __all__ = ["TreeNode"]
 
@@ -16,9 +17,21 @@ class TreeNode(object):
 
     def __init__(self, conducting_equipment: ConductingEquipment, parent: Optional[TreeNode]):
         self.conducting_equipment = conducting_equipment
-        self.parent = parent
+        self._parent = parent
         self._children: List[TreeNode] = []
         self._sort_weight = max((len(term.phases.single_phases) for term in conducting_equipment.terminals), default=1)
+
+    @property
+    def parent(self) -> Optional[TreeNode]:
+        return self._parent
+
+    @property
+    def children(self) -> Generator[TreeNode, None, None]:
+        return ngen(self._children)
+
+    @property
+    def sort_weight(self) -> int:
+        return self._sort_weight
 
     def __lt__(self, other: TreeNode):
         """
@@ -30,7 +43,7 @@ class TreeNode(object):
         return self._sort_weight > other._sort_weight
 
     def __str__(self):
-        return f"{{conducting_equipment: {self.conducting_equipment.mrid}, parent: {self.parent and self.parent.conducting_equipment.mrid}, " \
+        return f"{{conducting_equipment: {self.conducting_equipment.mrid}, parent: {self._parent and self._parent.conducting_equipment.mrid}, " \
                f"num children: {len(self._children)}}}"
 
     def add_child(self, child: TreeNode):

--- a/src/zepben/evolve/services/network/tracing/tree/tree_node_tracker.py
+++ b/src/zepben/evolve/services/network/tracing/tree/tree_node_tracker.py
@@ -6,7 +6,7 @@
 from typing import Set
 
 from zepben.evolve import Tracker, ConductingEquipment
-from zepben.evolve.services.network.tracing.tree.downstream_tree import TreeNode
+from zepben.evolve.services.network.tracing.tree.tree_node import TreeNode
 
 __all__ = ["TreeNodeTracker"]
 

--- a/src/zepben/evolve/services/network/tracing/tree/tree_node_tracker.py
+++ b/src/zepben/evolve/services/network/tracing/tree/tree_node_tracker.py
@@ -3,6 +3,8 @@
 #  This Source Code Form is subject to the terms of the Mozilla Public
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from __future__ import annotations
+
 from typing import Set
 
 from zepben.evolve import Tracker, ConductingEquipment
@@ -30,3 +32,7 @@ class TreeNodeTracker(Tracker[TreeNode]):
 
     def clear(self):
         self._visited.clear()
+
+    def copy(self) -> TreeNodeTracker:
+        # noinspection PyArgumentList
+        return TreeNodeTracker(_visited=self._visited.copy())

--- a/src/zepben/evolve/services/network/tracing/tree/tree_node_tracker.py
+++ b/src/zepben/evolve/services/network/tracing/tree/tree_node_tracker.py
@@ -1,0 +1,32 @@
+#  Copyright 2022 Zeppelin Bend Pty Ltd
+#
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from typing import Set
+
+from zepben.evolve import Tracker, ConductingEquipment
+from zepben.evolve.services.network.tracing.tree.downstream_tree import TreeNode
+
+__all__ = ["TreeNodeTracker"]
+
+
+class TreeNodeTracker(Tracker[TreeNode]):
+    """
+    Simple tracker for traversals that just tracks the items visited.
+    """
+
+    _visited: Set[ConductingEquipment] = set()
+
+    def has_visited(self, item: TreeNode) -> bool:
+        return item.conducting_equipment in self._visited
+
+    def visit(self, item: TreeNode) -> bool:
+        if item.conducting_equipment in self._visited:
+            return False
+        else:
+            self._visited.add(item.conducting_equipment)
+            return True
+
+    def clear(self):
+        self._visited.clear()

--- a/test/services/network/test_data/looping_network.py
+++ b/test/services/network/test_data/looping_network.py
@@ -1,0 +1,89 @@
+#  Copyright 2022 Zeppelin Bend Pty Ltd
+#
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from zepben.evolve import TestNetworkBuilder, PhaseCode
+
+
+def create_looping_network():
+    """
+    Network with loops in it. This was originally written in the JVM SDK without the use of TestNetworkBuilder.
+    Line lengths and impedances have been omitted in the absence of any tests where they matter.
+    :return: An example network with loops.
+    """
+    #
+    # j0   c1    j2   c13   j14  c15   j16
+    # *11------21*21------21*21------21*
+    #            3                     2
+    #            1                     1
+    #         c3 |                     | c17
+    #            2                     2
+    #            1    c20              1
+    #         j4 *21------21* j21      * b18 (open)
+    #            3                     2
+    #            1                     1
+    #         c5 |                     | c19
+    #            2                     2
+    #            1    c22  j23   c24   2
+    #         j6 *21------21*21------21* j25
+    #            3
+    #            1     c29
+    #            |      /--21* j30
+    #         c7 |     /     2
+    #            |    /      1
+    #            2   /       | c31
+    #            1  /        2
+    #         j8 *21   c9    2    c11
+    #            31--------21*31------21* j12
+    #             1        2 j10
+    #              \       |
+    #               \      1 c28
+    #                \     2
+    #                 \--21* j27
+    #                c26
+    #
+    return (
+        TestNetworkBuilder()
+        .from_junction(nominal_phases=PhaseCode.ABCN, num_terminals=1)  # j0
+        .to_acls(nominal_phases=PhaseCode.ABCN)  # c1
+        .to_junction(nominal_phases=PhaseCode.ABCN, num_terminals=3)  # j2
+        .to_acls(nominal_phases=PhaseCode.ABCN)  # c3
+        .to_junction(nominal_phases=PhaseCode.ABCN, num_terminals=3)  # j4
+        .to_acls(nominal_phases=PhaseCode.ABCN)  # c5
+        .to_junction(nominal_phases=PhaseCode.ABCN, num_terminals=3)  # j6
+        .to_acls(nominal_phases=PhaseCode.ABCN)  # c7
+        .to_junction(nominal_phases=PhaseCode.ABCN, num_terminals=3)  # j8
+        .to_acls(nominal_phases=PhaseCode.ABCN)  # c9
+        .to_junction(nominal_phases=PhaseCode.ABCN, num_terminals=3)  # j10
+        .to_acls(nominal_phases=PhaseCode.ABCN)  # c11
+        .to_junction(nominal_phases=PhaseCode.ABCN, num_terminals=1)  # j12
+        .branch_from("j2", 2)
+        .to_acls(nominal_phases=PhaseCode.ABCN)  # c13
+        .to_junction(nominal_phases=PhaseCode.ABCN)  # j14
+        .to_acls(nominal_phases=PhaseCode.ABCN)  # c15
+        .to_junction(nominal_phases=PhaseCode.ABCN)  # j16
+        .to_acls(nominal_phases=PhaseCode.ABCN)  # c17
+        .to_breaker(nominal_phases=PhaseCode.ABCN, is_normally_open=True)  # b18
+        .to_acls(nominal_phases=PhaseCode.ABCN)  # c19
+        .branch_from("j4", 2)
+        .to_acls(nominal_phases=PhaseCode.ABCN)  # c20
+        .to_junction(nominal_phases=PhaseCode.ABCN, num_terminals=1)  # j21
+        .branch_from("j6", 2)
+        .to_acls(nominal_phases=PhaseCode.ABCN)  # c22
+        .to_junction(nominal_phases=PhaseCode.ABCN)  # j23
+        .to_acls(nominal_phases=PhaseCode.ABCN)  # c24
+        .to_junction(nominal_phases=PhaseCode.ABCN)  # j25
+        .connect("c19", "j25", 2, 2)
+        .branch_from("j8", 2)
+        .to_acls(nominal_phases=PhaseCode.ABCN)  # c26
+        .to_junction(nominal_phases=PhaseCode.ABCN)  # j27
+        .to_acls(nominal_phases=PhaseCode.ABCN)  # c28
+        .connect("c28", "j10", 2, 2)
+        .branch_from("j8", 3)
+        .to_acls(nominal_phases=PhaseCode.ABCN)  # c29
+        .to_junction(nominal_phases=PhaseCode.ABCN)  # j30
+        .to_acls(nominal_phases=PhaseCode.ABCN)  # c31
+        .connect("c31", "j10", 2, 2)
+        .network
+    )

--- a/test/services/network/test_data/looping_network.py
+++ b/test/services/network/test_data/looping_network.py
@@ -75,12 +75,12 @@ def create_looping_network():
         .to_acls(nominal_phases=PhaseCode.ABCN)  # c24
         .to_junction(nominal_phases=PhaseCode.ABCN)  # j25
         .connect("c19", "j25", 2, 2)
-        .branch_from("j8", 2)
+        .branch_from("j8", 3)
         .to_acls(nominal_phases=PhaseCode.ABCN)  # c26
         .to_junction(nominal_phases=PhaseCode.ABCN)  # j27
         .to_acls(nominal_phases=PhaseCode.ABCN)  # c28
-        .connect("c28", "j10", 2, 2)
-        .branch_from("j8", 3)
+        .connect("c28", "j10", 2, 1)
+        .branch_from("j8", 2)
         .to_acls(nominal_phases=PhaseCode.ABCN)  # c29
         .to_junction(nominal_phases=PhaseCode.ABCN)  # j30
         .to_acls(nominal_phases=PhaseCode.ABCN)  # c31

--- a/test/services/network/tracing/connectivity/test_conducting_equipment_step_tracker.py
+++ b/test/services/network/tracing/connectivity/test_conducting_equipment_step_tracker.py
@@ -6,63 +6,95 @@
 from zepben.evolve import ConductingEquipmentStepTracker, ConductingEquipmentStep, Junction
 
 
-class TestConductingEquipmentStepTracker:
-
+def test_visited_step_is_reported_as_visited():
+    # noinspection PyArgumentList
+    step = ConductingEquipmentStep(Junction())
     tracker = ConductingEquipmentStepTracker()
 
-    def test_visited_step_is_reported_as_visited(self):
-        # noinspection PyArgumentList
-        step = ConductingEquipmentStep(Junction())
+    # pylint: disable=protected-access
+    print()
+    print(step.conducting_equipment)
+    print("----------------")
+    assert not tracker.has_visited(step), "has_visited returns false for unvisited equipment"
+    print(tracker._minimum_steps)
+    print("----------------")
+    assert tracker.visit(step), "Visiting unvisited equipment returns true"
+    print(tracker._minimum_steps)
+    print("----------------")
+    assert tracker.has_visited(step), "has_visited returns true for visited equipment"
+    print(tracker._minimum_steps)
+    print("----------------")
+    assert not tracker.visit(step), "Revisiting visited equipment returns false"
+    print(tracker._minimum_steps)
+    print("----------------")
+    # pylint: enable=protected-access
 
-        # pylint: disable=protected-access
-        print()
-        print(step.conducting_equipment)
-        print("----------------")
-        assert not(self.tracker.has_visited(step)), "has_visited returns false for unvisited equipment"
-        print(self.tracker._minimum_steps)
-        print("----------------")
-        assert self.tracker.visit(step), "Visiting unvisited equipment returns true"
-        print(self.tracker._minimum_steps)
-        print("----------------")
-        assert self.tracker.has_visited(step), "has_visited returns true for visited equipment"
-        print(self.tracker._minimum_steps)
-        print("----------------")
-        assert not(self.tracker.visit(step)), "Revisiting visited equipment returns false"
-        print(self.tracker._minimum_steps)
-        print("----------------")
-        # pylint: enable=protected-access
 
-    def test_smaller_step_for_same_equipment_is_reported_as_unvisited(self):
-        ce = Junction()
-        # noinspection PyArgumentList
-        step1 = ConductingEquipmentStep(ce, 1)
-        # noinspection PyArgumentList
-        step2 = ConductingEquipmentStep(ce)
+def test_smaller_step_for_same_equipment_is_reported_as_unvisited():
+    ce = Junction()
+    # noinspection PyArgumentList
+    step1 = ConductingEquipmentStep(ce, 1)
+    # noinspection PyArgumentList
+    step2 = ConductingEquipmentStep(ce)
 
-        self.tracker.visit(step1)
+    tracker = ConductingEquipmentStepTracker()
+    tracker.visit(step1)
 
-        assert not(self.tracker.has_visited(step2)), "has_visited returns false for smaller step of visited"
-        assert self.tracker.visit(step2), "Visiting smaller step of visited returns true"
+    assert not tracker.has_visited(step2), "has_visited returns false for smaller step of visited"
+    assert tracker.visit(step2), "Visiting smaller step of visited returns true"
 
-    def test_larger_step_for_same_equipment_is_reported_as_visited(self):
-        ce = Junction()
-        # noinspection PyArgumentList
-        step1 = ConductingEquipmentStep(ce)
-        # noinspection PyArgumentList
-        step2 = ConductingEquipmentStep(ce, 1)
 
-        self.tracker.visit(step1)
+def test_larger_step_for_same_equipment_is_reported_as_visited():
+    ce = Junction()
+    # noinspection PyArgumentList
+    step1 = ConductingEquipmentStep(ce)
+    # noinspection PyArgumentList
+    step2 = ConductingEquipmentStep(ce, 1)
 
-        assert self.tracker.has_visited(step2), "has_visited returns true for larger step of visited"
-        assert not(self.tracker.visit(step2)), "Visiting larger step of visited returns false"
+    tracker = ConductingEquipmentStepTracker()
+    tracker.visit(step1)
 
-    def test_steps_of_different_equipment_are_tracked_separately(self):
-        # noinspection PyArgumentList
-        step1 = ConductingEquipmentStep(Junction())
-        # noinspection PyArgumentList
-        step2 = ConductingEquipmentStep(Junction())
+    assert tracker.has_visited(step2), "has_visited returns true for larger step of visited"
+    assert not tracker.visit(step2), "Visiting larger step of visited returns false"
 
-        self.tracker.visit(step1)
 
-        assert not(self.tracker.has_visited(step2)), "has_visited returns false for same step on different equipment"
-        assert self.tracker.visit(step2), "Visiting same step on different equipment returns true"
+def test_steps_of_different_equipment_are_tracked_separately():
+    # noinspection PyArgumentList
+    step1 = ConductingEquipmentStep(Junction())
+    # noinspection PyArgumentList
+    step2 = ConductingEquipmentStep(Junction())
+
+    tracker = ConductingEquipmentStepTracker()
+    tracker.visit(step1)
+
+    assert not tracker.has_visited(step2), "has_visited returns false for same step on different equipment"
+    assert tracker.visit(step2), "Visiting same step on different equipment returns true"
+
+
+def test_clear():
+    # noinspection PyArgumentList
+    step = ConductingEquipmentStep(Junction())
+
+    tracker = ConductingEquipmentStepTracker()
+    tracker.visit(step)
+    tracker.clear()
+    
+    assert not tracker.has_visited(step), "clear un-visits all steps"
+
+
+def test_copy():
+    # noinspection PyArgumentList
+    step1 = ConductingEquipmentStep(Junction())
+    # noinspection PyArgumentList
+    step2 = ConductingEquipmentStep(Junction())
+    
+    tracker = ConductingEquipmentStepTracker()
+    # noinspection PyArgumentList
+    tracker.visit(step1)
+    
+    tracker_copy = tracker.copy()
+    assert tracker is not tracker_copy, "Tracker copy is not a reference to the original tracker"
+    assert tracker_copy.has_visited(step1), "Tracker copy reports has_visited as True for steps original tracker visited"
+
+    tracker_copy.visit(step2)
+    assert not tracker.has_visited(step2), "Tracker copy maintains separate tracking records"

--- a/test/services/network/tracing/connectivity/test_connectivity_tracker.py
+++ b/test/services/network/tracing/connectivity/test_connectivity_tracker.py
@@ -38,3 +38,18 @@ class TestConnectivityTracker:
 
         tracker.visit(cr1)
         assert tracker.has_visited(cr2), "Tracker has_visited connectivities with visited destination equipment"
+
+    def test_copy(self):
+        cr1 = ConnectivityResult(self.es_t, self.acls_t1, [])
+        cr2 = ConnectivityResult(self.acls_t2, self.ec_t, [])
+
+        tracker = ConnectivityTracker()
+        tracker.visit(cr1)
+
+        tracker_copy = tracker.copy()
+        assert tracker is not tracker_copy, "Tracker copy is not a reference to the original tracker"
+        assert tracker_copy.has_visited(cr1), "Tracker copy reports has_visited as True for steps original tracker visited"
+
+        tracker_copy.visit(cr2)
+        assert not tracker.has_visited(cr2), "Tracker copy maintains separate tracking records"
+

--- a/test/services/network/tracing/phases/test_phase_step_tracker.py
+++ b/test/services/network/tracing/phases/test_phase_step_tracker.py
@@ -65,3 +65,32 @@ def test_phases_of_different_equipment_are_tracked_separately():
 
     assert not tracker.has_visited(step2), "has_visited returns False for same phases on different equipment"
     assert tracker.visit(step2), "Visiting same phases on different equipment returns True"
+
+
+def test_clear():
+    # noinspection PyArgumentList
+    step = phase_step.start_at(Junction(), PhaseCode.ABCN)
+
+    tracker = PhaseStepTracker()
+    tracker.visit(step)
+    tracker.clear()
+
+    assert not tracker.has_visited(step), "clear un-visits all steps"
+
+
+def test_copy():
+    # noinspection PyArgumentList
+    step1 = phase_step.start_at(Junction(), PhaseCode.ABCN)
+    # noinspection PyArgumentList
+    step2 = phase_step.start_at(Junction(), PhaseCode.ABCN)
+
+    tracker = PhaseStepTracker()
+    # noinspection PyArgumentList
+    tracker.visit(step1)
+
+    tracker_copy = tracker.copy()
+    assert tracker is not tracker_copy, "Tracker copy is not a reference to the original tracker"
+    assert tracker_copy.has_visited(step1), "Tracker copy reports has_visited as True for steps original tracker visited"
+
+    tracker_copy.visit(step2)
+    assert not tracker.has_visited(step2), "Tracker copy maintains separate tracking records"

--- a/test/services/network/tracing/traversals/test_basic_tracker.py
+++ b/test/services/network/tracing/traversals/test_basic_tracker.py
@@ -1,0 +1,30 @@
+#  Copyright 2020 Zeppelin Bend Pty Ltd
+#
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from zepben.evolve import BasicTracker
+
+
+def test_single_item_and_clear():
+    tracker: BasicTracker[int] = BasicTracker()
+
+    assert not tracker.has_visited(123), "has_visited returns false for unvisited item"
+    assert tracker.visit(123), "Visiting unvisited equipment returns True"
+    assert tracker.has_visited(123), "has_visited returns True for visited item"
+    assert not tracker.visit(123), "Revisiting visited equipment returns False"
+    tracker.clear()
+    assert not tracker.has_visited(123), "Clearing delists all items"
+
+
+def test_copy():
+    tracker: BasicTracker[int] = BasicTracker()
+    # noinspection PyArgumentList
+    tracker.visit(1)
+
+    tracker_copy = tracker.copy()
+    assert tracker is not tracker_copy, "Tracker copy is not a reference to the original tracker"
+    assert tracker_copy.has_visited(1), "Tracker copy reports has_visited as True for steps original tracker visited"
+
+    tracker_copy.visit(2)
+    assert not tracker.has_visited(2), "Tracker copy maintains separate tracking records"

--- a/test/services/network/tracing/traversals/test_tracker.py
+++ b/test/services/network/tracing/traversals/test_tracker.py
@@ -1,0 +1,24 @@
+#  Copyright 2022 Zeppelin Bend Pty Ltd
+#
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from pytest import raises
+
+from zepben.evolve import Tracker
+
+
+def test_methods_are_abstract():
+    tracker = Tracker()
+
+    with raises(NotImplementedError):
+        tracker.has_visited(0)
+
+    with raises(NotImplementedError):
+        tracker.visit(0)
+
+    with raises(NotImplementedError):
+        tracker.clear()
+
+    with raises(NotImplementedError):
+        tracker.copy()

--- a/test/services/network/tracing/tree/__init__.py
+++ b/test/services/network/tracing/tree/__init__.py
@@ -1,0 +1,5 @@
+#  Copyright 2022 Zeppelin Bend Pty Ltd
+#
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/test/services/network/tracing/tree/test_downstream_trace.py
+++ b/test/services/network/tracing/tree/test_downstream_trace.py
@@ -1,0 +1,73 @@
+#  Copyright 2022 Zeppelin Bend Pty Ltd
+#
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from typing import Optional, List
+
+import pytest
+
+from services.network.test_data.looping_network import create_looping_network
+from zepben.evolve import set_phases, ConductingEquipment, set_direction, TreeNode
+from zepben.evolve.services.network.tracing.tracing import normal_downstream_tree
+
+
+@pytest.mark.asyncio
+async def test_downstream_trace():
+    n = create_looping_network()
+
+    await set_phases().run(n)
+    feeder_head = n.get("j0", ConductingEquipment)
+    await set_direction().run_terminal(feeder_head.get_terminal_by_sn(1))
+
+    start = n.get("j2", ConductingEquipment)
+    assert start is not None
+    root = await normal_downstream_tree().run(start)
+
+    assert root is not None
+    _verify_tree_asset(root, n["j2"], None, [n["c13"], n["c3"]])
+
+    test_node = next(iter(root.children))
+    _verify_tree_asset(test_node, n["c13"], n["j2"], [n["j14"]])
+
+    test_node = next(iter(test_node.children))
+    _verify_tree_asset(test_node, n["j14"], n["c13"], [n["c15"]])
+
+    test_node = next(iter(test_node.children))
+    _verify_tree_asset(test_node, n["c15"], n["j14"], [n["j16"]])
+
+    test_node = next(iter(test_node.children))
+    _verify_tree_asset(test_node, n["j16"], n["c15"], [n["c17"]])
+
+    test_node = next(iter(test_node.children))
+    _verify_tree_asset(test_node, n["c17"], n["j16"], [n["b18"]])
+
+    test_node = next(iter(test_node.children))
+    _verify_tree_asset(test_node, n["b18"], n["c17"], [])
+
+    test_node = list(root.children)[1]
+    _verify_tree_asset(test_node, n["c3"], n["j2"], [n["j4"]])
+
+    test_node = next(iter(test_node.children))
+    _verify_tree_asset(test_node, n["j4"], n["c3"], [n["c20"], n["c5"]])
+
+
+def _verify_tree_asset(
+    tree_node: TreeNode,
+    expected_asset: Optional[ConductingEquipment],
+    expected_parent: Optional[ConductingEquipment],
+    expected_children: List[ConductingEquipment]
+):
+    assert tree_node.conducting_equipment is expected_asset
+
+    if expected_parent is not None:
+        tree_parent = tree_node.parent
+        assert tree_parent is not None
+        assert tree_parent.conducting_equipment is expected_parent
+    else:
+        assert tree_node.parent is None
+
+    children_nodes = list(tree_node.children)
+    assert len(children_nodes) == len(expected_children)
+    for child_node, expected_child in zip(children_nodes, expected_children):
+        assert child_node.conducting_equipment is expected_child

--- a/test/services/network/tracing/tree/test_downstream_tree.py
+++ b/test/services/network/tracing/tree/test_downstream_tree.py
@@ -14,7 +14,7 @@ from zepben.evolve.services.network.tracing.tracing import normal_downstream_tre
 
 
 @pytest.mark.asyncio
-async def test_downstream_trace():
+async def test_downstream_tree():
     n = create_looping_network()
 
     await set_phases().run(n)
@@ -59,9 +59,64 @@ async def test_downstream_trace():
     assert len(_find_nodes(root, "j14")) == 1
     assert len(_find_nodes(root, "c15")) == 1
     assert len(_find_nodes(root, "j16")) == 1
+    assert len(_find_nodes(root, "c3")) == 1
+    assert len(_find_nodes(root, "j4")) == 1
     assert len(_find_nodes(root, "c17")) == 1
-    assert len(_find_nodes(root, "b18")) == 1
+    assert len(_find_nodes(root, "j21")) == 1
+    assert len(_find_nodes(root, "c20")) == 1
+    assert len(_find_nodes(root, "b18")) == 2
+    assert len(_find_nodes(root, "c5")) == 1
+    assert len(_find_nodes(root, "j6")) == 1
     assert len(_find_nodes(root, "c19")) == 1
+    assert len(_find_nodes(root, "j23")) == 1
+    assert len(_find_nodes(root, "c22")) == 1
+    assert len(_find_nodes(root, "j25")) == 1
+    assert len(_find_nodes(root, "c24")) == 1
+    assert len(_find_nodes(root, "j8")) == 1
+    assert len(_find_nodes(root, "c7")) == 1
+    assert len(_find_nodes(root, "j30")) == 1  # Would have been 3 if the intermediate loop was reprocessed.
+    assert len(_find_nodes(root, "c29")) == 1  # Would have been 3 if the intermediate loop was reprocessed.
+    assert len(_find_nodes(root, "j10")) == 3
+    assert len(_find_nodes(root, "c9")) == 4
+    assert len(_find_nodes(root, "j12")) == 3
+    assert len(_find_nodes(root, "c31")) == 1  # Would have been 3 if the intermediate loop was reprocessed.
+    assert len(_find_nodes(root, "j27")) == 4
+    assert len(_find_nodes(root, "c11")) == 3
+    assert len(_find_nodes(root, "c26")) == 4
+    assert len(_find_nodes(root, "c28")) == 4
+
+    assert _find_node_depths(root, "j0") == []
+    assert _find_node_depths(root, "c1") == []
+    assert _find_node_depths(root, "j2") == [0]
+    assert _find_node_depths(root, "c13") == [1]
+    assert _find_node_depths(root, "j14") == [2]
+    assert _find_node_depths(root, "c15") == [3]
+    assert _find_node_depths(root, "j16") == [4]
+    assert _find_node_depths(root, "c3") == [1]
+    assert _find_node_depths(root, "j4") == [2]
+    assert _find_node_depths(root, "c17") == [5]
+    assert _find_node_depths(root, "j21") == [4]
+    assert _find_node_depths(root, "c20") == [3]
+    assert _find_node_depths(root, "b18") == [6, 10]
+    assert _find_node_depths(root, "c5") == [3]
+    assert _find_node_depths(root, "j6") == [4]
+    assert _find_node_depths(root, "c19") == [9]
+    assert _find_node_depths(root, "j23") == [6]
+    assert _find_node_depths(root, "c22") == [5]
+    assert _find_node_depths(root, "j25") == [8]
+    assert _find_node_depths(root, "c24") == [7]
+    assert _find_node_depths(root, "j8") == [6]
+    assert _find_node_depths(root, "c7") == [5]
+    assert _find_node_depths(root, "j30") == [8]  # Would have been 8, 10, 12 if the intermediate loop was reprocessed.
+    assert _find_node_depths(root, "c29") == [7]  # Would have been 7, 11, 13 if the intermediate loop was reprocessed.
+    assert _find_node_depths(root, "j10") == [8, 10, 10]
+    assert _find_node_depths(root, "c9") == [7, 10, 11, 14]
+    assert _find_node_depths(root, "j12") == [10, 12, 12]
+    assert _find_node_depths(root, "c31") == [9]  # Would have been 9, 9, 11 if the intermediate loop was reprocessed.
+    assert _find_node_depths(root, "j27") == [8, 9, 12, 13]
+    assert _find_node_depths(root, "c11") == [9, 11, 11]
+    assert _find_node_depths(root, "c26") == [7, 10, 12, 13]
+    assert _find_node_depths(root, "c28") == [8, 9, 11, 14]
 
 
 def _verify_tree_asset(

--- a/test/services/network/tracing/tree/test_tree_node.py
+++ b/test/services/network/tracing/tree/test_tree_node.py
@@ -1,0 +1,68 @@
+#  Copyright 2022 Zeppelin Bend Pty Ltd
+#
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from typing import List
+
+from zepben.evolve import Junction, TreeNode, PhaseCode, Terminal
+
+
+def test_accessors():
+    tree_node_0 = TreeNode(Junction(mrid="node0"), None)
+    tree_node_1 = TreeNode(Junction(mrid="node1"), tree_node_0)
+    tree_node_2 = TreeNode(Junction(mrid="node2"), tree_node_0)
+    tree_node_3 = TreeNode(Junction(mrid="node3"), tree_node_0)
+    tree_node_4 = TreeNode(Junction(mrid="node4"), tree_node_3)
+    tree_node_5 = TreeNode(Junction(mrid="node5"), tree_node_3)
+    tree_node_6 = TreeNode(Junction(mrid="node6"), tree_node_5)
+    tree_node_7 = TreeNode(Junction(mrid="node7"), tree_node_6)
+    tree_node_8 = TreeNode(Junction(mrid="node8"), tree_node_7)
+    tree_node_9 = TreeNode(Junction(mrid="node9"), tree_node_8)
+
+    assert tree_node_0.conducting_equipment.mrid == "node0"
+    assert tree_node_0.parent is None
+
+    tree_node_0.add_child(tree_node_1)
+    tree_node_0.add_child(tree_node_2)
+    tree_node_0.add_child(tree_node_3)
+    tree_node_3.add_child(tree_node_4)
+    tree_node_3.add_child(tree_node_5)
+    tree_node_5.add_child(tree_node_6)
+    tree_node_6.add_child(tree_node_7)
+    tree_node_7.add_child(tree_node_8)
+    tree_node_8.add_child(tree_node_9)
+
+    children = list(tree_node_0.children)
+    assert tree_node_1 in children
+    assert tree_node_2 in children
+    assert tree_node_3 in children
+
+    tree_nodes = [tree_node_0, tree_node_1, tree_node_2, tree_node_3, tree_node_4, tree_node_5, tree_node_6, tree_node_7, tree_node_8, tree_node_9]
+    _assert_children(tree_nodes, [3, 0, 0, 2, 0, 1, 1, 1, 1, 0])
+    _assert_parents(tree_nodes, [-1, 0, 0, 0, 3, 3, 5, 6, 7, 8])
+
+
+def test_sort_weight():
+    tree_node_0 = TreeNode(Junction(mrid="node0"), None)
+    tree_node_1 = TreeNode(Junction(mrid="node1", terminals=[Terminal(phases=PhaseCode.AB)]), None)
+
+    assert tree_node_0.sort_weight == 1
+    assert tree_node_1.sort_weight == 2
+
+    # Nodes for equipment with more phases on their terminals come first when building equipment trees.
+    assert tree_node_1 < tree_node_0
+
+
+def _assert_children(tree_nodes: List[TreeNode], child_counts: List[int]):
+    assert len(tree_nodes) == len(child_counts)
+    for node, count in zip(tree_nodes, child_counts):
+        assert len(list(node.children)) == count
+
+
+def _assert_parents(tree_nodes: List[TreeNode], parents: List[int]):
+    for i, node in enumerate(tree_nodes):
+        if parents[i] < 0:
+            assert node.parent is None
+        else:
+            assert node.parent is tree_nodes[parents[i]]

--- a/test/services/network/tracing/tree/test_tree_node.py
+++ b/test/services/network/tracing/tree/test_tree_node.py
@@ -5,7 +5,7 @@
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from typing import List
 
-from zepben.evolve import Junction, TreeNode, PhaseCode, Terminal
+from zepben.evolve import Junction, TreeNode, PhaseCode, Terminal, AcLineSegment
 
 
 def test_accessors():
@@ -52,6 +52,15 @@ def test_sort_weight():
 
     # Nodes for equipment with more phases on their terminals come first when building equipment trees.
     assert tree_node_1 < tree_node_0
+
+
+def test_str():
+    tree_node_0 = TreeNode(Junction(mrid="junction"), None)
+    tree_node_1 = TreeNode(AcLineSegment(mrid="acls"), tree_node_0)
+    tree_node_0.add_child(tree_node_1)
+
+    assert str(tree_node_0) == "{conducting_equipment: junction, parent: None, num children: 1}"
+    assert str(tree_node_1) == "{conducting_equipment: acls, parent: junction, num children: 0}"
 
 
 def _assert_children(tree_nodes: List[TreeNode], child_counts: List[int]):

--- a/test/services/network/tracing/tree/test_tree_node_tracker.py
+++ b/test/services/network/tracing/tree/test_tree_node_tracker.py
@@ -28,3 +28,18 @@ def test_tracking_tree_nodes_with_same_equipment():
 
     tracker.visit(tn1)
     assert tracker.has_visited(tn2), "Tracker has_visited tree nodes with visited equipment"
+
+
+def test_copy():
+    tn1 = TreeNode(Breaker(), None)
+    tn2 = TreeNode(Breaker(), tn1)
+
+    tracker = TreeNodeTracker()
+    tracker.visit(tn1)
+
+    tracker_copy = tracker.copy()
+    assert tracker is not tracker_copy, "Tracker copy is not a reference to the original tracker"
+    assert tracker_copy.has_visited(tn1), "Tracker copy reports has_visited as True for steps original tracker visited"
+
+    tracker_copy.visit(tn2)
+    assert not tracker.has_visited(tn2), "Tracker copy maintains separate tracking records"

--- a/test/services/network/tracing/tree/test_tree_node_tracker.py
+++ b/test/services/network/tracing/tree/test_tree_node_tracker.py
@@ -4,7 +4,7 @@
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from zepben.evolve import Breaker
-from zepben.evolve.services.network.tracing.tree.downstream_tree import TreeNode
+from zepben.evolve.services.network.tracing.tree.tree_node import TreeNode
 from zepben.evolve.services.network.tracing.tree.tree_node_tracker import TreeNodeTracker
 
 

--- a/test/services/network/tracing/tree/test_tree_node_tracker.py
+++ b/test/services/network/tracing/tree/test_tree_node_tracker.py
@@ -1,0 +1,30 @@
+#  Copyright 2022 Zeppelin Bend Pty Ltd
+#
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from zepben.evolve import Breaker
+from zepben.evolve.services.network.tracing.tree.downstream_tree import TreeNode
+from zepben.evolve.services.network.tracing.tree.tree_node_tracker import TreeNodeTracker
+
+
+def test_single_tree_node_and_clear():
+    tracker = TreeNodeTracker()
+    tn = TreeNode(Breaker(), None)
+
+    assert not tracker.has_visited(tn), "has_visited returns false for unvisited equipment"
+    assert tracker.visit(tn), "Visiting unvisited equipment returns true"
+    assert tracker.has_visited(tn), "has_visited returns true for visited equipment"
+    assert not tracker.visit(tn), "Revisiting visited equipment returns false"
+    tracker.clear()
+    assert not tracker.has_visited(tn), "Clearing delists all equipment"
+
+
+def test_tracking_tree_nodes_with_same_equipment():
+    tracker = TreeNodeTracker()
+    ce = Breaker()
+    tn1 = TreeNode(ce, None)
+    tn2 = TreeNode(ce, tn1)
+
+    tracker.visit(tn1)
+    assert tracker.has_visited(tn2), "Tracker has_visited tree nodes with visited equipment"


### PR DESCRIPTION
# Description

- Add missing `run` method for `DownstreamTree`
- Add missing `TreeNodeTracker`
- Separate classes into their own files for `tree` submodule
- Add tests for `tree` submodule

# Associated tasks:

Tasks blocking this one:
- None

Tasks this is blocking:
- https://github.com/zepben/pp-translator/pull/19
- https://github.com/zepben/edith-sdk/pull/3

# Checklist:

- [x] I have performed a self review of my own code.
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have updated the changelog.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have considered if this is a breaking change and have communicated it with other team members if so.
