### PR TITLE
EWB-3257: Fix capitalization for auth header name

### DIFF
--- a/src/zepben/evolve/streaming/grpc/auth_token_plugin.py
+++ b/src/zepben/evolve/streaming/grpc/auth_token_plugin.py
@@ -8,7 +8,7 @@ from zepben.auth import ZepbenTokenFetcher
 
 __all__ = ["AuthTokenPlugin"]
 
-_AUTH_HEADER_KEY = 'Authorization'
+_AUTH_HEADER_KEY = 'authorization'
 
 
 class AuthTokenPlugin(grpc.AuthMetadataPlugin):

--- a/test/streaming/grpc/test_auth_token_plugin.py
+++ b/test/streaming/grpc/test_auth_token_plugin.py
@@ -16,4 +16,4 @@ def test_auth_token_plugin():
     plugin = AuthTokenPlugin(token_fetcher)
     plugin(Mock(), callback)
 
-    callback.assert_called_once_with((("Authorization", "fake token"),), None)
+    callback.assert_called_once_with((("authorization", "fake token"),), None)


### PR DESCRIPTION
Signed-off-by: Marcus Koh <marcus.koh@zepben.com>

# Description

gRPC gives "invalid metadata" unless the auth header is exactly "authorization" without capital letters. This fixes the issue.

# Associated tasks:

Tasks blocking this one:
- None

Tasks this is blocking:
- None

Tasks mirroring this one:
- Investigate issue in JVM gRPC connection functions (TBA)

# Checklist:

- [x] I have performed a self review of my own code.
- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [ ] I have updated the changelog.
- [ ] I have handled all new warnings generated by the compiler or IDE.
