### PR TITLE
Ewb 3454 dont resolve container equipment

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -95,6 +95,7 @@
 * Added missing `TreeNodeTracker`.
 * Classes in the `zepben.evolve.services.network.tracing.tree.*` submodules may now be imported `from zepben.evolve`.
 * Add `normal_upstream_trace`, `current_upstream_trace`, and `phase_inferrer` to `__all__` in `zepben.evolve.services.network.tracing.tracing`.
+* Stopped the NetworkConsumerClient from resolving the equipment of an EquipmentContainer when resolving references. Equipment for containers must always be explicitly requested by the client.
 
 ### Notes
 

--- a/src/zepben/evolve/streaming/get/network_consumer.py
+++ b/src/zepben/evolve/streaming/get/network_consumer.py
@@ -529,6 +529,10 @@ class NetworkConsumerClient(CimConsumerClient[NetworkService]):
             to_resolve = set()
             for obj in res.objects:
                 for ref in self.service.get_unresolved_references_from(obj):
+                    # Skip any reference trying to resolve from an EquipmentContainer - e.g a PowerTransformer trying to pull in its LvFeeder.
+                    # EquipmentContainers should be retrieved explicitly or via a hierarchy call.
+                    if EquipmentContainer in ref.resolver.from_class.__bases__:
+                        continue
                     to_resolve.add(ref.to_mrid)
 
             response = await self._get_identified_objects(to_resolve)

--- a/test/streaming/get/mock_server.py
+++ b/test/streaming/get/mock_server.py
@@ -22,6 +22,12 @@ GrpcResponse = TypeVar('GrpcResponse')
 class StreamGrpc:
     function: str
     processors: List[Callable[[GrpcRequest], Generator[GrpcResponse, None, None]]]
+    """
+    The processors to run in order for this function StreamGrpc.
+    For example if you expect getIdentifiedObjects to be called twice in a row, you could provide two processors for getIdentifiedObjects here, rather
+    than two separate StreamGrpcs
+    """
+
     force_timeout: bool = False
 
 
@@ -60,6 +66,12 @@ class MockServer:
         self.grpc_service: ServiceDescriptor = grpc_service
 
     async def validate(self, client_test: Callable[[], Awaitable[None]], interactions: List[Union[StreamGrpc, UnaryGrpc]]):
+        """
+        Run a server that mocks RPC requests by invoking the provided `interactions` in order.
+
+        :param client_test: The test code to call.
+        :param interactions: An ordered list of interactions expected for this server.
+        """
         server = CatchingThread(target=self._run_server_logic, args=[interactions])
         server.start()
 


### PR DESCRIPTION
# Description

Stops the client from pulling in equipment for edge containers - e.g an open switch with 2 LvFeeders.

# Checklist:

These are always required, if you do not do them, reviewers will be angry:
- [x] I have performed a self review of my own code.
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.

These you can remove from the list if they are not applicable for this PR.
- [x] I have updated the changelog.
- [x] I have updated any documentation required for these changes.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have considered if this is a breaking change and have communicated it with other team members if so.
