### PR TITLE
Only skip resolving EquipmentContainers on subsequent resolves

### DIFF
--- a/src/zepben/evolve/testing/test_network_builder.py
+++ b/src/zepben/evolve/testing/test_network_builder.py
@@ -353,7 +353,7 @@ class TestNetworkBuilder:
                 for terminal in es.terminals:
                     await set_direction().run_terminal(terminal)
 
-        if assign_feeders and len(list(self.network.objects(Feeder))) != 0:
+        if assign_feeders and (self.network.len_of(Feeder) != 0 or self.network.len_of(LvFeeder) != 0):
             await assign_equipment_to_feeders().run(self.network)
             await assign_equipment_to_lv_feeders().run(self.network)
 

--- a/test/network_fixtures.py
+++ b/test/network_fixtures.py
@@ -15,7 +15,7 @@ from zepben.evolve import NetworkService, Feeder, PhaseCode, EnergySource, Energ
 __all__ = ["create_terminals", "create_junction_for_connecting", "create_source_for_connecting", "create_switch_for_connecting", "create_acls_for_connecting",
            "create_energy_consumer_for_connecting", "create_feeder", "create_substation", "create_power_transformer_for_connecting", "create_terminals",
            "create_geographical_region", "create_subgeographical_region", "create_asset_owner", "create_meter", "create_power_transformer_end",
-           "feeder_network", "lv_feeder_with_open_point", "feeder_start_point_between_conductors_network", "feeder_start_point_to_open_point_network",
+           "feeder_network", "feeder_start_point_between_conductors_network", "feeder_start_point_to_open_point_network",
            "feeder_with_current", "operational_restriction_with_equipment", "create_connectivitynode_with_terminals",
            "single_connectivitynode_network", "create_terminal", "phase_swap_loop_network", "loop_under_feeder_head_network", "network_service"]
 
@@ -342,36 +342,6 @@ async def feeder_network():
 
     await SetPhases().run(network_service)
     await AssignToFeeders().run(network_service)
-    return network_service
-
-
-@fixture()
-async def lv_feeder_with_open_point():
-    """
-    lv1:[     c1  {  ]  c2     }:lv2
-    lv1:[tx1------{sw]------tx2}:lv2
-    """
-    network_service = NetworkService()
-
-    sw = create_switch_for_connecting(network_service, "sw", 2, PhaseCode.AB)
-    sw.set_open(True)
-    sw.set_normally_open(True)
-    tx1 = create_power_transformer_for_connecting(network_service, "tx1", 2, PhaseCode.AB, end_args=[{"rated_u": 22000}, {"rated_u": 415}])
-    tx2 = create_power_transformer_for_connecting(network_service, "tx2", 2, PhaseCode.AB, end_args=[{"rated_u": 22000}, {"rated_u": 415}])
-
-    c1 = create_acls_for_connecting(network_service, "c1", PhaseCode.AB)
-    c2 = create_acls_for_connecting(network_service, "c2", PhaseCode.AB)
-
-    create_lv_feeder(network_service, "lvf001", "lvf001", head_terminal=tx1.get_terminal_by_sn(2))
-    create_lv_feeder(network_service, "lvf002", "lvf002", head_terminal=tx2.get_terminal_by_sn(2))
-
-    network_service.connect_terminals(c1.get_terminal_by_sn(1), tx1.get_terminal_by_sn(2))
-    network_service.connect_terminals(c2.get_terminal_by_sn(1), tx2.get_terminal_by_sn(2))
-    network_service.connect_terminals(c1.get_terminal_by_sn(2), sw.get_terminal_by_sn(2))
-    network_service.connect_terminals(c2.get_terminal_by_sn(2), sw.get_terminal_by_sn(1))
-
-    await SetPhases().run(network_service)
-    await AssignToLvFeeders().run(network_service)
     return network_service
 
 


### PR DESCRIPTION
# Description

Extra fix such that we resolve EquipmentContainers only on the first loop

# Checklist:

These are always required, if you do not do them, reviewers will be angry:
- [ ] I have performed a self review of my own code.
- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.

These you can remove from the list if they are not applicable for this PR.
- [ ] I have updated the changelog.
- [ ] I have updated any documentation required for these changes.
- [ ] I have commented my code in any hard-to-understand or hacky areas.
- [ ] I have handled all new warnings generated by the compiler or IDE.
- [ ] I have considered if this is a breaking change and have communicated it with other team members if so.
