### PR TITLE
EWB-3614: Performance enhancement for `ConnectedEquipmentTrace`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -81,6 +81,7 @@
     * `TreeNode().sort_weight` has been added as a read-only property that returns the sort weight of the node.
 * All `Tracker` classes can now be copied using the `copy` method.
 * Added `FeederDirection.__not__` operator function.
+* Performance enhancement for `connected_equipment_trace.py` when traversing elements with single terminals.
 
 ### Fixes
 

--- a/src/zepben/evolve/services/network/tracing/connectivity/connected_equipment_trace.py
+++ b/src/zepben/evolve/services/network/tracing/connectivity/connected_equipment_trace.py
@@ -34,7 +34,7 @@ __all__ = ["new_connected_equipment_trace", "new_connected_equipment_breadth_tra
 
 def _queue_next(open_test: OpenTest) -> QueueNext[ConductingEquipmentStep]:
     def queue_next(step: ConductingEquipmentStep, traversal: BasicTraversal[ConductingEquipmentStep]):
-        if (step.step != 0) and open_test(step.conducting_equipment, None):
+        if (step.step != 0) and ((step.conducting_equipment.num_terminals() == 1) or open_test(step.conducting_equipment, None)):
             return
         for cr in connected_equipment(step.conducting_equipment):
             if cr.to_equip:


### PR DESCRIPTION
# Description

Performance enhancement for `ConnectedEquipmentTrace` when traversing elements with single terminals.

# Checklist:

These are always required, if you do not do them, reviewers will be angry:
- [x] I have performed a self review of my own code.
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.

These you can remove from the list if they are not applicable for this PR.
- [x] I have updated the changelog.
~- [ ] I have updated any documentation required for these changes.~
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have considered if this is a breaking change and have communicated it with other team members if so.
