### PR TITLE
EWB-3793: LV2 support and trace enhancements

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -31,8 +31,8 @@
 
   Note that `from zepben.evolve import <ClassName>` will still work as usual for all of the above classes.
 * `DatabaseReader().load` is now an asynchronous function.
-* The addition of the `mrid` arguments to the `TestNetworkBuilder` functions has changed the position of the `action` argument. If you are using positional
-  arguments you will need to add `action=` before your actions if you do not specify your own mRID.
+* The addition of the `mrid` and `connectivity_node_mrid` arguments to the `TestNetworkBuilder` functions has changed the position of the `action` argument. If
+  you are using positional arguments you will need to add `action=` before your actions if you do not specify your own mRIDs.
 * `SetDirection.run(NetworkService)` will no longer set directions for feeders with a head terminal on an open switch. It is expected these feeders are either
   placeholder feeders with no meaningful equipment, or are energised from another feeder which will set the directions from the other end.
 
@@ -96,6 +96,7 @@
     * Added Kotlin wrappers for `.fromOther` and `.toOther` that allow you to pass a class type rather than a creator. e.g. `.toOther<Fuse>()` instead
       of `.toOther(::Fuse)` or `.toOther( { Fuse(it) } )`.
     * Added inbuilt support for `PowerElectronicsConnection` and `EnergyConsumer`
+    * The `to*` and `connect` functions can specify the connectivity node mRID to use. This will only be used if the terminals are not already connected.
 * Added `+` and `-` operators to `PhaseCode` and `SinglePhaseKind`.
 
 ### Fixes

--- a/changelog.md
+++ b/changelog.md
@@ -21,16 +21,20 @@
   with `BOTH.__contains__(DOWNSTREAM)` or `DOWNSTREAM in BOTH`
 * Removed deprecated function `NetworkConsumerClient.get_feeder`.
 * Refactored the following `Switch` descendant classes to their own submodules in `zepben.evolve.model.cim.iec61970.base.wires`:
-  * `Breaker` moved to `breaker`
-  * `Disconnector` moved to `disconnector`
-  * `Fuse` moved to `fuse`
-  * `Jumper` moved to `jumper`
-  * `LoadBreakSwitch` moved to `load_break_switch`
-  * `ProtectedSwitch` moved to `protected_switch`
-  * `Recloser` moved to `recloser`
-  
+    * `Breaker` moved to `breaker`
+    * `Disconnector` moved to `disconnector`
+    * `Fuse` moved to `fuse`
+    * `Jumper` moved to `jumper`
+    * `LoadBreakSwitch` moved to `load_break_switch`
+    * `ProtectedSwitch` moved to `protected_switch`
+    * `Recloser` moved to `recloser`
+
   Note that `from zepben.evolve import <ClassName>` will still work as usual for all of the above classes.
-* `DatabaseReader().load` is now an asynchronous function. 
+* `DatabaseReader().load` is now an asynchronous function.
+* The addition of the `mrid` arguments to the `TestNetworkBuilder` functions has changed the position of the `action` argument. If you are using positional
+  arguments you will need to add `action=` before your actions if you do not specify your own mRID.
+* `SetDirection.run(NetworkService)` will no longer set directions for feeders with a head terminal on an open switch. It is expected these feeders are either
+  placeholder feeders with no meaningful equipment, or are energised from another feeder which will set the directions from the other end.
 
 ### New Features
 
@@ -55,19 +59,19 @@
     * `new_current_downstream_equipment_trace`: Creates a trace that traverses in the downstream direction using the current state of the network.
     * `new_current_upstream_equipment_trace`: Creates a trace that traverses in the upstream direction using the current state of the network.
 * Added support for protection equipment with the following classes, enums, and fields:
-  * `SwitchInfo`: Switch datasheet information.
-  * `ProtectionEquipment`: An electrical device designed to respond to input conditions in a prescribed manner and after specified conditions are met to cause
-                           contact operation or similar abrupt change in associated electric control circuits, or simply to display the detected condition.
-  * `CurrentRelay`: A device that checks current flow values in any direction or designated direction.
-  * `CurrentRelayInfo`: Current relay datasheet information.
-  * `RecloseSequence`: A reclose sequence (open and close) is defined for each possible reclosure of a breaker.
-  * `ProtectionKind`: The kind of protection being provided by this protection equipment.
-  * `ProtectedSwitch().breaking_capacity`: The maximum fault current in amps a breaking device can break safely under prescribed conditions of use.
-  * `ProtectedSwitch().reclose_sequences`: The collection of `RecloseSequence`s attached to the `ProtectedSwitch`.
-  * `ProtectedSwitch().operated_by_protection_equipment`: The collection of `ProtectionEquipment` operating the `ProtectedSwitch`.
-  * `Switch().rated_current`: The maximum continuous current carrying capacity in amps governed by the device material and construction.
-                            The attribute shall be a positive value.
-  * `Breaker().in_transit_time`: The transition time from open to close in seconds.
+    * `SwitchInfo`: Switch datasheet information.
+    * `ProtectionEquipment`: An electrical device designed to respond to input conditions in a prescribed manner and after specified conditions are met to cause
+      contact operation or similar abrupt change in associated electric control circuits, or simply to display the detected condition.
+    * `CurrentRelay`: A device that checks current flow values in any direction or designated direction.
+    * `CurrentRelayInfo`: Current relay datasheet information.
+    * `RecloseSequence`: A reclose sequence (open and close) is defined for each possible reclosure of a breaker.
+    * `ProtectionKind`: The kind of protection being provided by this protection equipment.
+    * `ProtectedSwitch().breaking_capacity`: The maximum fault current in amps a breaking device can break safely under prescribed conditions of use.
+    * `ProtectedSwitch().reclose_sequences`: The collection of `RecloseSequence`s attached to the `ProtectedSwitch`.
+    * `ProtectedSwitch().operated_by_protection_equipment`: The collection of `ProtectionEquipment` operating the `ProtectedSwitch`.
+    * `Switch().rated_current`: The maximum continuous current carrying capacity in amps governed by the device material and construction.
+      The attribute shall be a positive value.
+    * `Breaker().in_transit_time`: The transition time from open to close in seconds.
 * Added `getCustomersForContainer` to `CustomerConsumerClient` which allows fetching all the `Customer`s for a given `EquipmentContainer`
 * Added `getDiagramObjects` to `DiagramConsumerClient` which allows fetching all the `DiagramObject`s matching a given mRID.
 
@@ -82,6 +86,13 @@
 * All `Tracker` classes can now be copied using the `copy` method.
 * Added `FeederDirection.__not__` operator function.
 * Performance enhancement for `connected_equipment_trace.py` when traversing elements with single terminals.
+* Added support for LV2 transformers.
+* Improved logging when saving a database.
+* The `TestNetworkBuilder` has been enhanced with the following features:
+    * You can now set the ID's without having to create a customer 'other' creator.
+    * Added Kotlin wrappers for `.fromOther` and `.toOther` that allow you to pass a class type rather than a creator. e.g. `.toOther<Fuse>()` instead
+      of `.toOther(::Fuse)` or `.toOther( { Fuse(it) } )`.
+* Added `+` and `-` operators to `PhaseCode` and `SinglePhaseKind`.
 
 ### Fixes
 
@@ -97,9 +108,11 @@
 * Added missing `TreeNodeTracker`.
 * Classes in the `zepben.evolve.services.network.tracing.tree.*` submodules may now be imported `from zepben.evolve`.
 * Add `normal_upstream_trace`, `current_upstream_trace`, and `phase_inferrer` to `__all__` in `zepben.evolve.services.network.tracing.tracing`.
-* Stopped the NetworkConsumerClient from resolving the equipment of an EquipmentContainer when resolving references. Equipment for containers must always be explicitly requested by the client.
+* Stopped the NetworkConsumerClient from resolving the equipment of an EquipmentContainer when resolving references. Equipment for containers must always be
+  explicitly requested by the client.
 * Asking for the traced phases as a phase code when there are no nominal phases no longer throws.
-* Added missing nio type to nio_typ_to_cim in network_consumer.py
+* Feeder directions are now stopped at substation transformers in the same way as assigning equipment incase the feeder has no breaker, or the start point is
+  not inline.
 
 ### Notes
 

--- a/changelog.md
+++ b/changelog.md
@@ -95,6 +95,7 @@
     * You can now set the ID's without having to create a customer 'other' creator.
     * Added Kotlin wrappers for `.fromOther` and `.toOther` that allow you to pass a class type rather than a creator. e.g. `.toOther<Fuse>()` instead
       of `.toOther(::Fuse)` or `.toOther( { Fuse(it) } )`.
+    * Added inbuilt support for `PowerElectronicsConnection` and `EnergyConsumer`
 * Added `+` and `-` operators to `PhaseCode` and `SinglePhaseKind`.
 
 ### Fixes

--- a/changelog.md
+++ b/changelog.md
@@ -74,6 +74,9 @@
     * `Breaker().in_transit_time`: The transition time from open to close in seconds.
 * Added `getCustomersForContainer` to `CustomerConsumerClient` which allows fetching all the `Customer`s for a given `EquipmentContainer`
 * Added `getDiagramObjects` to `DiagramConsumerClient` which allows fetching all the `DiagramObject`s matching a given mRID.
+* `Traversal` has two new helper methods:
+    * `if_not_stopping`: Adds a step action that is only called if the traversal is not stopping on the item.
+    * `if_stopping`: Adds a step action that is only called if the traversal is stopping on the item.
 
 ### Enhancements
 

--- a/src/zepben/evolve/__init__.py
+++ b/src/zepben/evolve/__init__.py
@@ -4,6 +4,9 @@
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+# We need to import SinglePhaseKind before anything uses PhaseCode to prevent cyclic dependencies.
+from zepben.evolve.model.cim.iec61970.base.wires.single_phase_kind import *
+
 from zepben.evolve.model.cim.iec61968.customers.pricing_structure import *
 from zepben.evolve.model.cim.iec61968.customers.customer_agreement import *
 from zepben.evolve.model.cim.iec61968.customers.customer_kind import *
@@ -82,7 +85,6 @@ from zepben.evolve.model.cim.iec61970.base.wires.jumper import *
 from zepben.evolve.model.cim.iec61970.base.wires.load_break_switch import *
 from zepben.evolve.model.cim.iec61970.base.wires.recloser import *
 from zepben.evolve.model.cim.iec61970.base.wires.energy_source import *
-from zepben.evolve.model.cim.iec61970.base.wires.single_phase_kind import *
 from zepben.evolve.model.cim.iec61970.base.wires.energy_connection import *
 from zepben.evolve.model.cim.iec61970.base.wires.transformer_star_impedance import *
 from zepben.evolve.model.cim.iec61970.base.core.substation import *

--- a/src/zepben/evolve/model/cim/iec61970/base/core/phase_code.py
+++ b/src/zepben/evolve/model/cim/iec61970/base/core/phase_code.py
@@ -5,7 +5,7 @@
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 from enum import Enum, unique
-from typing import List, Set
+from typing import List, Set, Union
 
 from zepben.evolve.model.cim.iec61970.base.wires.single_phase_kind import SinglePhaseKind
 
@@ -119,6 +119,7 @@ class PhaseCode(Enum):
 
     s2N = (27, [SinglePhaseKind.s2, SinglePhaseKind.N])
     """Secondary phase 2 plus neutral"""
+
     # pylint: enable=invalid-name
 
     @property
@@ -152,6 +153,22 @@ class PhaseCode(Enum):
 
     def __contains__(self, item):
         return item in self.single_phases
+
+    def __add__(self, other: Union[SinglePhaseKind, 'PhaseCode']) -> 'PhaseCode':
+        if isinstance(other, SinglePhaseKind):
+            return phase_code_from_single_phases(set(self.single_phases + [other]))
+        elif isinstance(other, PhaseCode):
+            return phase_code_from_single_phases(set(self.single_phases + other.single_phases))
+        else:
+            return PhaseCode.NONE
+
+    def __sub__(self, other: Union[SinglePhaseKind, 'PhaseCode']) -> 'PhaseCode':
+        if isinstance(other, SinglePhaseKind):
+            return phase_code_from_single_phases({it for it in self.single_phases if it != other})
+        elif isinstance(other, PhaseCode):
+            return phase_code_from_single_phases({it for it in self.single_phases if it not in other.single_phases})
+        else:
+            return PhaseCode.NONE
 
 
 class PhaseCodeIter:

--- a/src/zepben/evolve/model/cim/iec61970/base/wires/single_phase_kind.py
+++ b/src/zepben/evolve/model/cim/iec61970/base/wires/single_phase_kind.py
@@ -5,6 +5,12 @@
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 from enum import Enum
+from typing import Union
+
+#
+# NOTE: The following import is actually at the bottom of this file to avoid cyclic imports.
+#
+# from zepben.evolve.model.cim.iec61970.base.core.phase_code import phase_code_from_single_phases, PhaseCode
 
 __all__ = ["SinglePhaseKind", "single_phase_kind_by_id", "SINGLE_PHASE_KIND_VALUES"]
 
@@ -71,5 +77,26 @@ class SinglePhaseKind(Enum):
     def __lt__(self, other):
         return self.id < other.id
 
+    def __add__(self, other: Union['SinglePhaseKind', 'PhaseCode']) -> 'PhaseCode':
+        if isinstance(other, SinglePhaseKind):
+            return phase_code_from_single_phases({self, other})
+        elif isinstance(other, PhaseCode):
+            return phase_code_from_single_phases(set(other.single_phases + [self]))
+        else:
+            return PhaseCode.NONE
+
+    def __sub__(self, other: Union['SinglePhaseKind', 'PhaseCode']) -> 'PhaseCode':
+        if isinstance(other, SinglePhaseKind):
+            return phase_code_from_single_phases({} if (self == other) else {self})
+        elif isinstance(other, PhaseCode):
+            return phase_code_from_single_phases({} if (self in other) else {self})
+        else:
+            return PhaseCode.NONE
+
 
 SINGLE_PHASE_KIND_VALUES = list(SinglePhaseKind.__members__.values())
+
+#
+# NOTE: The following import is deliberately at the bottom of this file to avoid cyclic imports.
+#
+from zepben.evolve.model.cim.iec61970.base.core.phase_code import phase_code_from_single_phases, PhaseCode  # noqa: E402

--- a/src/zepben/evolve/services/network/tracing/connectivity/transformer_phase_paths.py
+++ b/src/zepben/evolve/services/network/tracing/connectivity/transformer_phase_paths.py
@@ -21,7 +21,7 @@ _add_neutral = _path(Phase.NONE, Phase.N)
 transformer_phase_paths: Dict[PhaseCode, Dict[PhaseCode, List[NominalPhasePath]]] = {
     PhaseCode.ABCN: {
         PhaseCode.ABCN: [_path(Phase.A, Phase.A), _path(Phase.B, Phase.B), _path(Phase.C, Phase.C), _path(Phase.N, Phase.N)],
-        PhaseCode.ABC: [_path(Phase.A, Phase.A), _path(Phase.B, Phase.B), _path(Phase.C, Phase.C)]
+        PhaseCode.ABC: [_path(Phase.A, Phase.A), _path(Phase.B, Phase.B), _path(Phase.C, Phase.C)],
     },
     PhaseCode.AN: {
         PhaseCode.AN: [_path(Phase.A, Phase.A), _path(Phase.N, Phase.N)],
@@ -65,7 +65,47 @@ transformer_phase_paths: Dict[PhaseCode, Dict[PhaseCode, List[NominalPhasePath]]
         PhaseCode.ABCN: [_path(Phase.A, Phase.A), _path(Phase.B, Phase.B), _path(Phase.C, Phase.C), _add_neutral],
         PhaseCode.ABC: [_path(Phase.A, Phase.A), _path(Phase.B, Phase.B), _path(Phase.C, Phase.C)],
     },
+    PhaseCode.ABN: {
+        PhaseCode.ABN: [_path(Phase.A, Phase.A), _path(Phase.B, Phase.B), _path(Phase.N, Phase.N)],
+        PhaseCode.XYN: [_path(Phase.A, Phase.X), _path(Phase.B, Phase.Y), _path(Phase.N, Phase.N)],
+        PhaseCode.AB: [_path(Phase.A, Phase.A), _path(Phase.B, Phase.B)],
+        PhaseCode.XY: [_path(Phase.A, Phase.X), _path(Phase.B, Phase.Y)],
+        PhaseCode.A: [_path(Phase.A, Phase.A)],
+        PhaseCode.X: [_path(Phase.A, Phase.X)],
+    },
+    PhaseCode.BCN: {
+        PhaseCode.BCN: [_path(Phase.B, Phase.B), _path(Phase.C, Phase.C), _path(Phase.N, Phase.N)],
+        PhaseCode.XYN: [_path(Phase.B, Phase.X), _path(Phase.C, Phase.Y), _path(Phase.N, Phase.N)],
+        PhaseCode.BC: [_path(Phase.B, Phase.B), _path(Phase.C, Phase.C)],
+        PhaseCode.XY: [_path(Phase.B, Phase.X), _path(Phase.C, Phase.Y)],
+        PhaseCode.B: [_path(Phase.B, Phase.B)],
+        PhaseCode.X: [_path(Phase.B, Phase.X)],
+    },
+    PhaseCode.ACN: {
+        PhaseCode.ACN: [_path(Phase.A, Phase.A), _path(Phase.C, Phase.C), _path(Phase.N, Phase.N)],
+        PhaseCode.XYN: [_path(Phase.A, Phase.X), _path(Phase.C, Phase.Y), _path(Phase.N, Phase.N)],
+        PhaseCode.AC: [_path(Phase.A, Phase.A), _path(Phase.C, Phase.C)],
+        PhaseCode.XY: [_path(Phase.A, Phase.X), _path(Phase.C, Phase.Y)],
+        PhaseCode.C: [_path(Phase.C, Phase.C)],
+        PhaseCode.X: [_path(Phase.C, Phase.X)],
+    },
+    PhaseCode.XYN: {
+        PhaseCode.ABN: [_path(Phase.X, Phase.A), _path(Phase.Y, Phase.B), _path(Phase.N, Phase.N)],
+        PhaseCode.BCN: [_path(Phase.X, Phase.B), _path(Phase.Y, Phase.C), _path(Phase.N, Phase.N)],
+        PhaseCode.ACN: [_path(Phase.X, Phase.A), _path(Phase.Y, Phase.C), _path(Phase.N, Phase.N)],
+        PhaseCode.XYN: [_path(Phase.X, Phase.X), _path(Phase.Y, Phase.Y), _path(Phase.N, Phase.N)],
+        PhaseCode.AB: [_path(Phase.X, Phase.A), _path(Phase.Y, Phase.B)],
+        PhaseCode.BC: [_path(Phase.X, Phase.B), _path(Phase.Y, Phase.C)],
+        PhaseCode.AC: [_path(Phase.X, Phase.A), _path(Phase.Y, Phase.C)],
+        PhaseCode.XY: [_path(Phase.X, Phase.X), _path(Phase.Y, Phase.Y)],
+        PhaseCode.A: [_path(Phase.X, Phase.A)],
+        PhaseCode.B: [_path(Phase.X, Phase.B)],
+        PhaseCode.C: [_path(Phase.X, Phase.C)],
+        PhaseCode.X: [_path(Phase.X, Phase.X)],
+    },
     PhaseCode.AB: {
+        PhaseCode.ABN: [_path(Phase.A, Phase.A), _path(Phase.B, Phase.B), _add_neutral],
+        PhaseCode.XYN: [_path(Phase.A, Phase.X), _path(Phase.B, Phase.Y), _add_neutral],
         PhaseCode.AN: [_path(Phase.A, Phase.A), _add_neutral],
         PhaseCode.XN: [_path(Phase.A, Phase.X), _add_neutral],
         PhaseCode.AB: [_path(Phase.A, Phase.A), _path(Phase.B, Phase.B)],
@@ -74,6 +114,8 @@ transformer_phase_paths: Dict[PhaseCode, Dict[PhaseCode, List[NominalPhasePath]]
         PhaseCode.X: [_path(Phase.A, Phase.X)],
     },
     PhaseCode.BC: {
+        PhaseCode.BCN: [_path(Phase.B, Phase.B), _path(Phase.C, Phase.C), _add_neutral],
+        PhaseCode.XYN: [_path(Phase.B, Phase.X), _path(Phase.C, Phase.Y), _add_neutral],
         PhaseCode.BN: [_path(Phase.B, Phase.B), _add_neutral],
         PhaseCode.XN: [_path(Phase.B, Phase.X), _add_neutral],
         PhaseCode.BC: [_path(Phase.B, Phase.B), _path(Phase.C, Phase.C)],
@@ -82,6 +124,8 @@ transformer_phase_paths: Dict[PhaseCode, Dict[PhaseCode, List[NominalPhasePath]]
         PhaseCode.X: [_path(Phase.B, Phase.X)],
     },
     PhaseCode.AC: {
+        PhaseCode.ACN: [_path(Phase.A, Phase.A), _path(Phase.C, Phase.C), _add_neutral],
+        PhaseCode.XYN: [_path(Phase.A, Phase.X), _path(Phase.C, Phase.Y), _add_neutral],
         PhaseCode.CN: [_path(Phase.C, Phase.C), _add_neutral],
         PhaseCode.XN: [_path(Phase.C, Phase.X), _add_neutral],
         PhaseCode.AC: [_path(Phase.A, Phase.A), _path(Phase.C, Phase.C)],
@@ -90,6 +134,10 @@ transformer_phase_paths: Dict[PhaseCode, Dict[PhaseCode, List[NominalPhasePath]]
         PhaseCode.X: [_path(Phase.C, Phase.X)],
     },
     PhaseCode.XY: {
+        PhaseCode.ABN: [_path(Phase.X, Phase.A), _path(Phase.Y, Phase.B), _add_neutral],
+        PhaseCode.BCN: [_path(Phase.X, Phase.B), _path(Phase.Y, Phase.C), _add_neutral],
+        PhaseCode.ACN: [_path(Phase.X, Phase.A), _path(Phase.Y, Phase.C), _add_neutral],
+        PhaseCode.XYN: [_path(Phase.X, Phase.X), _path(Phase.Y, Phase.Y), _add_neutral],
         PhaseCode.AN: [_path(Phase.X, Phase.A), _add_neutral],
         PhaseCode.BN: [_path(Phase.X, Phase.B), _add_neutral],
         PhaseCode.CN: [_path(Phase.X, Phase.C), _add_neutral],
@@ -110,6 +158,8 @@ transformer_phase_paths: Dict[PhaseCode, Dict[PhaseCode, List[NominalPhasePath]]
         PhaseCode.XY: [_path(Phase.A, Phase.X), _path(Phase.NONE, Phase.Y)],
         PhaseCode.A: [_path(Phase.A, Phase.A)],
         PhaseCode.X: [_path(Phase.A, Phase.X)],
+        PhaseCode.ABN: [_path(Phase.A, Phase.A), _path(Phase.NONE, Phase.B), _add_neutral],
+        PhaseCode.XYN: [_path(Phase.A, Phase.X), _path(Phase.NONE, Phase.Y), _add_neutral],
     },
     PhaseCode.B: {
         PhaseCode.BN: [_path(Phase.B, Phase.B), _add_neutral],
@@ -118,6 +168,8 @@ transformer_phase_paths: Dict[PhaseCode, Dict[PhaseCode, List[NominalPhasePath]]
         PhaseCode.XY: [_path(Phase.B, Phase.X), _path(Phase.NONE, Phase.Y)],
         PhaseCode.B: [_path(Phase.B, Phase.B)],
         PhaseCode.X: [_path(Phase.B, Phase.X)],
+        PhaseCode.BCN: [_path(Phase.B, Phase.B), _path(Phase.NONE, Phase.C), _add_neutral],
+        PhaseCode.XYN: [_path(Phase.B, Phase.X), _path(Phase.NONE, Phase.Y), _add_neutral],
     },
     PhaseCode.C: {
         PhaseCode.CN: [_path(Phase.C, Phase.C), _add_neutral],
@@ -126,6 +178,8 @@ transformer_phase_paths: Dict[PhaseCode, Dict[PhaseCode, List[NominalPhasePath]]
         PhaseCode.XY: [_path(Phase.C, Phase.X), _path(Phase.NONE, Phase.Y)],
         PhaseCode.C: [_path(Phase.C, Phase.C)],
         PhaseCode.X: [_path(Phase.C, Phase.X)],
+        PhaseCode.ACN: [_path(Phase.C, Phase.C), _path(Phase.NONE, Phase.A), _add_neutral],
+        PhaseCode.XYN: [_path(Phase.C, Phase.X), _path(Phase.NONE, Phase.Y), _add_neutral],
     },
     PhaseCode.X: {
         PhaseCode.AN: [_path(Phase.X, Phase.A), _add_neutral],
@@ -140,5 +194,9 @@ transformer_phase_paths: Dict[PhaseCode, Dict[PhaseCode, List[NominalPhasePath]]
         PhaseCode.B: [_path(Phase.X, Phase.B)],
         PhaseCode.C: [_path(Phase.X, Phase.C)],
         PhaseCode.X: [_path(Phase.X, Phase.X)],
+        PhaseCode.ABN: [_path(Phase.X, Phase.A), _path(Phase.NONE, Phase.B), _add_neutral],
+        PhaseCode.BCN: [_path(Phase.X, Phase.B), _path(Phase.NONE, Phase.C), _add_neutral],
+        PhaseCode.ACN: [_path(Phase.X, Phase.C), _path(Phase.NONE, Phase.A), _add_neutral],
+        PhaseCode.XYN: [_path(Phase.X, Phase.X), _path(Phase.NONE, Phase.Y), _add_neutral],
     },
 }

--- a/src/zepben/evolve/services/network/tracing/traversals/traversal.py
+++ b/src/zepben/evolve/services/network/tracing/traversals/traversal.py
@@ -99,6 +99,36 @@ class Traversal(Generic[T]):
         self.step_actions.append(action)
         return self
 
+    def if_not_stopping(self, action: Callable[[T], Awaitable[None]]) -> Traversal[T]:
+        """
+        Add a callback which is called for every item in the traversal that does not match a stop condition (including the starting item).
+    
+        :param action: Action to be called on each item in the traversal that is not being stopped on.
+        :return: This traversal instance.
+        """
+
+        async def wrapper(item: T, is_stopping: bool) -> None:
+            if not is_stopping:
+                await action(item)
+
+        self.step_actions.append(wrapper)
+        return self
+
+    def if_stopping(self, action: Callable[[T], Awaitable[None]]) -> Traversal[T]:
+        """
+        Add a callback which is called for every item in the traversal that matches a stop condition (including the starting item).
+    
+        :param action: Action to be called on each item in the traversal that is being stopped on.
+        :return: This traversal instance.
+        """
+
+        async def wrapper(item: T, is_stopping: bool) -> None:
+            if is_stopping:
+                await action(item)
+
+        self.step_actions.append(wrapper)
+        return self
+
     def copy_stop_conditions(self, other: Traversal[T]):
         """Copy the stop conditions from `other` to this `Traversal`."""
         self.stop_conditions.extend(other.stop_conditions)

--- a/src/zepben/evolve/testing/test_network_builder.py
+++ b/src/zepben/evolve/testing/test_network_builder.py
@@ -71,6 +71,7 @@ class TestNetworkBuilder:
         self,
         nominal_phases: PhaseCode = PhaseCode.ABC,
         mrid: Optional[str] = None,
+        connectivity_node_mrid: Optional[str] = None,
         action: Callable[[EnergySource], None] = null_action
     ) -> 'TestNetworkBuilder':
         """
@@ -78,12 +79,14 @@ class TestNetworkBuilder:
 
         :param nominal_phases: The `PhaseCode` for the new `EnergySource`, used as both the nominal and energising phases. Must be a subset of `PhaseCode.ABCN`.
         :param mrid: Optional mRID for the new source.
+        :param connectivity_node_mrid: Optional id of the connectivity node used to connect this `EnergySource` to the previous item. Will only be used if the
+         previous item is not already connected.
         :param action: An action that accepts the new `EnergySource` to allow for additional initialisation.
 
         :return: This `TestNetworkBuilder` to allow for fluent use.
         """
         it = self._create_external_source(mrid, nominal_phases)
-        self._connect(self._current, it)
+        self._connect(self._current, it, connectivity_node_mrid)
         action(it)
         self._current = it
         return self
@@ -112,6 +115,7 @@ class TestNetworkBuilder:
         self,
         nominal_phases: PhaseCode = PhaseCode.ABC,
         mrid: Optional[str] = None,
+        connectivity_node_mrid: Optional[str] = None,
         action: Callable[[AcLineSegment], None] = null_action
     ) -> 'TestNetworkBuilder':
         """
@@ -119,12 +123,14 @@ class TestNetworkBuilder:
 
         :param nominal_phases: The nominal phases for the new `AcLineSegment`.
         :param mrid: Optional mRID for the new `AcLineSegment`.
+        :param connectivity_node_mrid: Optional id of the connectivity node used to connect this `AcLineSegment` to the previous item. Will only be used if the
+         previous item is not already connected.
         :param action: An action that accepts the new `AcLineSegment` to allow for additional initialisation.
 
         :return: This `TestNetworkBuilder` to allow for fluent use.
         """
         acls = self._create_acls(mrid, nominal_phases)
-        self._connect(self._current, acls)
+        self._connect(self._current, acls, connectivity_node_mrid)
         action(acls)
         self._current = acls
         return self
@@ -159,6 +165,7 @@ class TestNetworkBuilder:
         is_normally_open: bool = False,
         is_open: Optional[bool] = None,
         mrid: Optional[str] = None,
+        connectivity_node_mrid: Optional[str] = None,
         action: Callable[[Breaker], None] = null_action
     ) -> 'TestNetworkBuilder':
         """
@@ -168,12 +175,14 @@ class TestNetworkBuilder:
         :param is_normally_open: The normal state of the switch. Defaults to False.
         :param is_open: The current state of the switch. Defaults to `is_normally_open`.
         :param mrid: Optional mRID for the new `Breaker`.
+        :param connectivity_node_mrid: Optional id of the connectivity node used to connect this `Breaker` to the previous item. Will only be used if the
+         previous item is not already connected.
         :param action: An action that accepts the new `Breaker` to allow for additional initialisation.
 
         :return: This `TestNetworkBuilder` to allow for fluent use.
         """
         it = self._create_breaker(mrid, nominal_phases, is_normally_open=is_normally_open, is_open=is_open if is_open is not None else is_normally_open)
-        self._connect(self._current, it)
+        self._connect(self._current, it, connectivity_node_mrid)
         action(it)
         self._current = it
         return self
@@ -205,6 +214,7 @@ class TestNetworkBuilder:
         nominal_phases: PhaseCode = PhaseCode.ABC,
         num_terminals: Optional[int] = None,
         mrid: Optional[str] = None,
+        connectivity_node_mrid: Optional[str] = None,
         action: Callable[[Junction], None] = null_action
     ) -> 'TestNetworkBuilder':
         """
@@ -213,12 +223,14 @@ class TestNetworkBuilder:
         :param nominal_phases: The nominal phases for the new `Junction`.
         :param num_terminals: The number of terminals to create on the new `Junction`. Defaults to 2.
         :param mrid: Optional mRID for the new `Junction`.
+        :param connectivity_node_mrid: Optional id of the connectivity node used to connect this `Junction` to the previous item. Will only be used if the
+         previous item is not already connected.
         :param action: An action that accepts the new `Junction` to allow for additional initialisation.
 
         :return: This `TestNetworkBuilder` to allow for fluent use.
         """
         it = self._create_junction(mrid, nominal_phases, num_terminals)
-        self._connect(self._current, it)
+        self._connect(self._current, it, connectivity_node_mrid)
         action(it)
         self._current = it
         return self
@@ -228,6 +240,7 @@ class TestNetworkBuilder:
         nominal_phases: PhaseCode = PhaseCode.ABC,
         num_terminals: Optional[int] = None,
         mrid: Optional[str] = None,
+        connectivity_node_mrid: Optional[str] = None,
         action: Callable[[PowerElectronicsConnection], None] = null_action
     ) -> 'TestNetworkBuilder':
         """
@@ -237,12 +250,14 @@ class TestNetworkBuilder:
         :param nominal_phases: The nominal phases for the new `PowerElectronicsConnection`.
         :param num_terminals: The number of terminals to create on the new `PowerElectronicsConnection`. Defaults to 2.
         :param mrid: Optional mRID for the new `PowerElectronicsConnection`.
+        :param connectivity_node_mrid: Optional id of the connectivity node used to connect this `PowerElectronicsConnection` to the previous item. Will only be
+         used if the previous item is not already connected.
         :param action: An action that accepts the new `PowerElectronicsConnection` to allow for additional initialisation.
 
         :return: This `TestNetworkBuilder` to allow for fluent use.
         """
         it = self._create_power_electronics_connection(mrid, nominal_phases, num_terminals)
-
+        self._connect(self._current, it, connectivity_node_mrid)
         action(it)
         self._current = it
         return self
@@ -277,6 +292,7 @@ class TestNetworkBuilder:
         nominal_phases: Optional[List[PhaseCode]] = None,
         end_actions: Optional[List[Callable[[PowerTransformerEnd], None]]] = None,
         mrid: Optional[str] = None,
+        connectivity_node_mrid: Optional[str] = None,
         action: Callable[[PowerTransformer], None] = null_action
     ) -> 'TestNetworkBuilder':
         """
@@ -286,10 +302,12 @@ class TestNetworkBuilder:
         :param end_actions: Actions that accepts the new `PowerTransformerEnd` to allow for additional initialisation.
         :param action: An action that accepts the new `PowerTransformer` to allow for additional initialisation.
         :param mrid: Optional mRID for the new `PowerTransformer`.
+        :param connectivity_node_mrid: Optional id of the connectivity node used to connect this `PowerTransformer` to the previous item. Will only be used if
+         the previous item is not already connected.
         :return: This `TestNetworkBuilder` to allow for fluent use.
         """
         it = self._create_power_transformer(mrid, nominal_phases or [PhaseCode.ABC, PhaseCode.ABC])
-        self._connect(self._current, it)
+        self._connect(self._current, it, connectivity_node_mrid)
 
         if end_actions:
             for i in range(0, it.num_ends()):
@@ -303,6 +321,7 @@ class TestNetworkBuilder:
         self,
         nominal_phases: PhaseCode = PhaseCode.ABC,
         mrid: Optional[str] = None,
+        connectivity_node_mrid: Optional[str] = None,
         action: Callable[[EnergyConsumer], None] = null_action
     ) -> 'TestNetworkBuilder':
         """
@@ -311,12 +330,14 @@ class TestNetworkBuilder:
 
         :param nominal_phases: The nominal phases for the new `EnergyConsumer`.
         :param mrid: Optional mRID for the new `EnergyConsumer`.
+        :param connectivity_node_mrid: Optional id of the connectivity node used to connect this `EnergyConsumer` to the previous item. Will only be used if the
+         previous item is not already connected.
         :param action: An action that accepts the new `EnergyConsumer` to allow for additional initialisation.
 
         :return: This `TestNetworkBuilder` to allow for fluent use.
         """
         it = self._create_energy_consumer(mrid, nominal_phases)
-
+        self._connect(self._current, it, connectivity_node_mrid)
         action(it)
         self._current = it
         return self
@@ -352,6 +373,7 @@ class TestNetworkBuilder:
         nominal_phases: PhaseCode = PhaseCode.ABC,
         num_terminals: Optional[int] = None,
         mrid: Optional[str] = None,
+        connectivity_node_mrid: Optional[str] = None,
         action: Callable[[ConductingEquipment], None] = null_action
     ) -> 'TestNetworkBuilder':
         """
@@ -363,12 +385,14 @@ class TestNetworkBuilder:
         :param nominal_phases: The nominal phases for the new `ConductingEquipment`.
         :param num_terminals: The number of terminals to create on the new `ConductingEquipment`. Defaults to 2.
         :param mrid: Optional mRID for the new `ConductingEquipment`.
+        :param connectivity_node_mrid: Optional id of the connectivity node used to connect this `ConductingEquipment` to the previous item. Will only be used
+         if the previous item is not already connected.
         :param action: An action that accepts the new `ConductingEquipment` to allow for additional initialisation.
 
         :return: This `TestNetworkBuilder` to allow for fluent use.
         """
         it = self._create_other(mrid, creator, nominal_phases, num_terminals)
-        self._connect(self._current, it)
+        self._connect(self._current, it, connectivity_node_mrid)
         action(it)
         self._current = it
         return self
@@ -386,7 +410,14 @@ class TestNetworkBuilder:
         self._current_terminal = terminal
         return self
 
-    def connect(self, from_: str, to: str, from_terminal: int, to_terminal: int) -> 'TestNetworkBuilder':
+    def connect(
+        self,
+        from_: str,
+        to: str,
+        from_terminal: int,
+        to_terminal: int,
+        connectivity_node_mrid: Optional[str] = None
+    ) -> 'TestNetworkBuilder':
         """
         Connect the specified `from` and `to` without moving the current network pointer.
 
@@ -394,10 +425,18 @@ class TestNetworkBuilder:
         :param to: The mRID of the second `ConductingEquipment` to be connected.
         :param from_terminal: The sequence number of the terminal on `from` which will be connected.
         :param to_terminal: The sequence number of the terminal on `to` which will be connected.
+        :param connectivity_node_mrid: Optional id of the connectivity node used to connect the terminals. Will only be used if both terminals are not already
+         connected.
 
         :return: This `TestNetworkBuilder` to allow for fluent use.
         """
-        self._connect(self.network.get(from_, ConductingEquipment), self.network.get(to, ConductingEquipment), from_terminal, to_terminal)
+        self._connect(
+            self.network.get(from_, ConductingEquipment),
+            self.network.get(to, ConductingEquipment),
+            connectivity_node_mrid,
+            from_terminal,
+            to_terminal
+        )
         return self
 
     def add_feeder(self, head_mrid: str, sequence_number: Optional[int] = None, mrid: Optional[str] = None) -> 'TestNetworkBuilder':
@@ -456,11 +495,21 @@ class TestNetworkBuilder:
         self._count += 1
         return id_
 
-    def _connect(self, from_: ConductingEquipment, to: ConductingEquipment, from_terminal: Optional[int] = None, to_terminal: Optional[int] = None):
-        self.network.connect_terminals(
-            from_.get_terminal_by_sn(from_terminal if from_terminal else self._current_terminal if self._current_terminal else from_.num_terminals()),
-            to.get_terminal_by_sn(to_terminal if to_terminal else 1)
-        )
+    def _connect(
+        self,
+        from_: ConductingEquipment,
+        to: ConductingEquipment,
+        connectivity_node_mrid: Optional[str] = None,
+        from_terminal: Optional[int] = None,
+        to_terminal: Optional[int] = None
+    ):
+        from_term = from_.get_terminal_by_sn(from_terminal if from_terminal else self._current_terminal if self._current_terminal else from_.num_terminals())
+        to_term = to.get_terminal_by_sn(to_terminal if to_terminal else 1)
+        if (connectivity_node_mrid is None) or from_term.connected or to_term.connected:
+            self.network.connect_terminals(from_term, to_term)
+        else:
+            self.network.connect_by_mrid(from_term, connectivity_node_mrid)
+            self.network.connect_by_mrid(to_term, connectivity_node_mrid)
         self._current_terminal = None
 
     def _create_external_source(self, mrid: Optional[str], nominal_phases: PhaseCode) -> EnergySource:

--- a/src/zepben/evolve/testing/test_network_builder.py
+++ b/src/zepben/evolve/testing/test_network_builder.py
@@ -46,59 +46,83 @@ class TestNetworkBuilder:
         self._current: Optional[ConductingEquipment] = None
         self._current_terminal: Optional[int] = None
 
-    def from_source(self, nominal_phases: PhaseCode = PhaseCode.ABC, action: Callable[[EnergySource], None] = null_action) -> 'TestNetworkBuilder':
+    def from_source(
+        self,
+        nominal_phases: PhaseCode = PhaseCode.ABC,
+        mrid: Optional[str] = None,
+        action: Callable[[EnergySource], None] = null_action
+    ) -> 'TestNetworkBuilder':
         """
         Start a new network island from an `EnergySource`, updating the network pointer to the new `EnergySource`.
 
         :param nominal_phases: The `PhaseCode` for the new `EnergySource`, used as both the nominal and energising phases. Must be a subset of `PhaseCode.ABCN`.
+        :param mrid: Optional mRID for the new source.
         :param action: An action that accepts the new `EnergySource` to allow for additional initialisation.
 
         :return: This `TestNetworkBuilder` to allow for fluent use.
         """
-        it = self._create_external_source(nominal_phases)
+        it = self._create_external_source(mrid, nominal_phases)
         action(it)
         self._current = it
         return self
 
-    def to_source(self, nominal_phases: PhaseCode = PhaseCode.ABC, action: Callable[[EnergySource], None] = null_action) -> 'TestNetworkBuilder':
+    def to_source(
+        self,
+        nominal_phases: PhaseCode = PhaseCode.ABC,
+        mrid: Optional[str] = None,
+        action: Callable[[EnergySource], None] = null_action
+    ) -> 'TestNetworkBuilder':
         """
         Add a new `EnergySource` to the network and connect it to the current network pointer, updating the network pointer to the new `EnergySource`.
 
         :param nominal_phases: The `PhaseCode` for the new `EnergySource`, used as both the nominal and energising phases. Must be a subset of `PhaseCode.ABCN`.
+        :param mrid: Optional mRID for the new source.
         :param action: An action that accepts the new `EnergySource` to allow for additional initialisation.
 
         :return: This `TestNetworkBuilder` to allow for fluent use.
         """
-        it = self._create_external_source(nominal_phases)
+        it = self._create_external_source(mrid, nominal_phases)
         self._connect(self._current, it)
         action(it)
         self._current = it
         return self
 
-    def from_acls(self, nominal_phases: PhaseCode = PhaseCode.ABC, action: Callable[[AcLineSegment], None] = null_action) -> 'TestNetworkBuilder':
+    def from_acls(
+        self,
+        nominal_phases: PhaseCode = PhaseCode.ABC,
+        mrid: Optional[str] = None,
+        action: Callable[[AcLineSegment], None] = null_action
+    ) -> 'TestNetworkBuilder':
         """
         Start a new network island from an `AcLineSegment`, updating the network pointer to the new `AcLineSegment`.
 
         :param nominal_phases: The nominal phases for the new `AcLineSegment`.
+        :param mrid: Optional mRID for the new `AcLineSegment`.
         :param action: An action that accepts the new `AcLineSegment` to allow for additional initialisation.
 
         :return: This `TestNetworkBuilder` to allow for fluent use.
         """
-        it = self._create_acls(nominal_phases)
+        it = self._create_acls(mrid, nominal_phases)
         action(it)
         self._current = it
         return self
 
-    def to_acls(self, nominal_phases: PhaseCode = PhaseCode.ABC, action: Callable[[AcLineSegment], None] = null_action) -> 'TestNetworkBuilder':
+    def to_acls(
+        self,
+        nominal_phases: PhaseCode = PhaseCode.ABC,
+        mrid: Optional[str] = None,
+        action: Callable[[AcLineSegment], None] = null_action
+    ) -> 'TestNetworkBuilder':
         """
         Add a new `AcLineSegment` to the network and connect it to the current network pointer, updating the network pointer to the new `AcLineSegment`.
 
         :param nominal_phases: The nominal phases for the new `AcLineSegment`.
+        :param mrid: Optional mRID for the new `AcLineSegment`.
         :param action: An action that accepts the new `AcLineSegment` to allow for additional initialisation.
 
         :return: This `TestNetworkBuilder` to allow for fluent use.
         """
-        acls = self._create_acls(nominal_phases)
+        acls = self._create_acls(mrid, nominal_phases)
         self._connect(self._current, acls)
         action(acls)
         self._current = acls
@@ -109,6 +133,7 @@ class TestNetworkBuilder:
         nominal_phases: PhaseCode = PhaseCode.ABC,
         is_normally_open: bool = False,
         is_open: Optional[bool] = None,
+        mrid: Optional[str] = None,
         action: Callable[[Breaker], None] = null_action
     ) -> 'TestNetworkBuilder':
         """
@@ -117,11 +142,12 @@ class TestNetworkBuilder:
         :param nominal_phases: The nominal phases for the new `Breaker`.
         :param is_normally_open: The normal state of the switch. Defaults to False.
         :param is_open: The current state of the switch. Defaults to `is_normally_open`.
+        :param mrid: Optional mRID for the new `Breaker`.
         :param action: An action that accepts the new `Breaker` to allow for additional initialisation.
 
         :return: This `TestNetworkBuilder` to allow for fluent use.
         """
-        it = self._create_breaker(nominal_phases, is_normally_open=is_normally_open, is_open=is_open if is_open is not None else is_normally_open)
+        it = self._create_breaker(mrid, nominal_phases, is_normally_open=is_normally_open, is_open=is_open if is_open is not None else is_normally_open)
         action(it)
         self._current = it
         return self
@@ -131,6 +157,7 @@ class TestNetworkBuilder:
         nominal_phases: PhaseCode = PhaseCode.ABC,
         is_normally_open: bool = False,
         is_open: Optional[bool] = None,
+        mrid: Optional[str] = None,
         action: Callable[[Breaker], None] = null_action
     ) -> 'TestNetworkBuilder':
         """
@@ -139,11 +166,12 @@ class TestNetworkBuilder:
         :param nominal_phases: The nominal phases for the new `Breaker`.
         :param is_normally_open: The normal state of the switch. Defaults to False.
         :param is_open: The current state of the switch. Defaults to `is_normally_open`.
+        :param mrid: Optional mRID for the new `Breaker`.
         :param action: An action that accepts the new `Breaker` to allow for additional initialisation.
 
         :return: This `TestNetworkBuilder` to allow for fluent use.
         """
-        it = self._create_breaker(nominal_phases, is_normally_open=is_normally_open, is_open=is_open if is_open is not None else is_normally_open)
+        it = self._create_breaker(mrid, nominal_phases, is_normally_open=is_normally_open, is_open=is_open if is_open is not None else is_normally_open)
         self._connect(self._current, it)
         action(it)
         self._current = it
@@ -153,6 +181,7 @@ class TestNetworkBuilder:
         self,
         nominal_phases: PhaseCode = PhaseCode.ABC,
         num_terminals: Optional[int] = None,
+        mrid: Optional[str] = None,
         action: Callable[[Junction], None] = null_action
     ) -> 'TestNetworkBuilder':
         """
@@ -160,11 +189,12 @@ class TestNetworkBuilder:
 
         :param nominal_phases: The nominal phases for the new `Junction`.
         :param num_terminals: The number of terminals to create on the new `Junction`. Defaults to 2.
+        :param mrid: Optional mRID for the new `Junction`.
         :param action: An action that accepts the new `Junction` to allow for additional initialisation.
 
         :return: This `TestNetworkBuilder` to allow for fluent use.
         """
-        it = self._create_junction(nominal_phases, num_terminals)
+        it = self._create_junction(mrid, nominal_phases, num_terminals)
         action(it)
         self._current = it
         return self
@@ -173,6 +203,7 @@ class TestNetworkBuilder:
         self,
         nominal_phases: PhaseCode = PhaseCode.ABC,
         num_terminals: Optional[int] = None,
+        mrid: Optional[str] = None,
         action: Callable[[Junction], None] = null_action
     ) -> 'TestNetworkBuilder':
         """
@@ -180,11 +211,12 @@ class TestNetworkBuilder:
 
         :param nominal_phases: The nominal phases for the new `Junction`.
         :param num_terminals: The number of terminals to create on the new `Junction`. Defaults to 2.
+        :param mrid: Optional mRID for the new `Junction`.
         :param action: An action that accepts the new `Junction` to allow for additional initialisation.
 
         :return: This `TestNetworkBuilder` to allow for fluent use.
         """
-        it = self._create_junction(nominal_phases, num_terminals)
+        it = self._create_junction(mrid, nominal_phases, num_terminals)
         self._connect(self._current, it)
         action(it)
         self._current = it
@@ -194,6 +226,7 @@ class TestNetworkBuilder:
         self,
         nominal_phases: Optional[List[PhaseCode]] = None,
         end_actions: Optional[List[Callable[[PowerTransformerEnd], None]]] = None,
+        mrid: Optional[str] = None,
         action: Callable[[PowerTransformer], None] = null_action
     ) -> 'TestNetworkBuilder':
         """
@@ -202,9 +235,10 @@ class TestNetworkBuilder:
         :param nominal_phases: The nominal phases for each end of the new `PowerTransformer`. Defaults to two `PhaseCode.ABC` ends.
         :param end_actions: Actions that accepts the new `PowerTransformerEnd` to allow for additional initialisation.
         :param action: An action that accepts the new `PowerTransformer` to allow for additional initialisation.
+        :param mrid: Optional mRID for the new `PowerTransformer`.
         :return: This `TestNetworkBuilder` to allow for fluent use.
         """
-        it = self._create_power_transformer(nominal_phases or [PhaseCode.ABC, PhaseCode.ABC])
+        it = self._create_power_transformer(mrid, nominal_phases or [PhaseCode.ABC, PhaseCode.ABC])
         if end_actions:
             for i in range(0, it.num_ends()):
                 end_actions[i](it.get_end_by_num(i + 1))
@@ -217,6 +251,7 @@ class TestNetworkBuilder:
         self,
         nominal_phases: List[PhaseCode] = None,
         end_actions: Optional[List[Callable[[PowerTransformerEnd], None]]] = None,
+        mrid: Optional[str] = None,
         action: Callable[[PowerTransformer], None] = null_action
     ) -> 'TestNetworkBuilder':
         """
@@ -225,9 +260,10 @@ class TestNetworkBuilder:
         :param nominal_phases: The nominal phases for each end of the new `PowerTransformer`. Defaults to two `PhaseCode.ABC` ends.
         :param end_actions: Actions that accepts the new `PowerTransformerEnd` to allow for additional initialisation.
         :param action: An action that accepts the new `PowerTransformer` to allow for additional initialisation.
+        :param mrid: Optional mRID for the new `PowerTransformer`.
         :return: This `TestNetworkBuilder` to allow for fluent use.
         """
-        it = self._create_power_transformer(nominal_phases or [PhaseCode.ABC, PhaseCode.ABC])
+        it = self._create_power_transformer(mrid, nominal_phases or [PhaseCode.ABC, PhaseCode.ABC])
         self._connect(self._current, it)
 
         if end_actions:
@@ -243,6 +279,7 @@ class TestNetworkBuilder:
         creator: Union[OtherCreator, Type[ConductingEquipment]],
         nominal_phases: PhaseCode = PhaseCode.ABC,
         num_terminals: Optional[int] = None,
+        mrid: Optional[str] = None,
         action: Callable[[ConductingEquipment], None] = null_action
     ) -> 'TestNetworkBuilder':
         """
@@ -252,11 +289,12 @@ class TestNetworkBuilder:
               `ConductingEquipment`.
         :param nominal_phases: The nominal phases for the new `ConductingEquipment`.
         :param num_terminals: The number of terminals to create on the new `ConductingEquipment`. Defaults to 2.
+        :param mrid: Optional mRID for the new `ConductingEquipment`.
         :param action: An action that accepts the new `ConductingEquipment` to allow for additional initialisation.
 
         :return: This `TestNetworkBuilder` to allow for fluent use.
         """
-        it = self._create_other(creator, nominal_phases, num_terminals)
+        it = self._create_other(mrid, creator, nominal_phases, num_terminals)
         action(it)
         self._current = it
         return self
@@ -266,6 +304,7 @@ class TestNetworkBuilder:
         creator: Union[OtherCreator, Type[ConductingEquipment]],
         nominal_phases: PhaseCode = PhaseCode.ABC,
         num_terminals: Optional[int] = None,
+        mrid: Optional[str] = None,
         action: Callable[[ConductingEquipment], None] = null_action
     ) -> 'TestNetworkBuilder':
         """
@@ -276,11 +315,12 @@ class TestNetworkBuilder:
               `ConductingEquipment`.
         :param nominal_phases: The nominal phases for the new `ConductingEquipment`.
         :param num_terminals: The number of terminals to create on the new `ConductingEquipment`. Defaults to 2.
+        :param mrid: Optional mRID for the new `ConductingEquipment`.
         :param action: An action that accepts the new `ConductingEquipment` to allow for additional initialisation.
 
         :return: This `TestNetworkBuilder` to allow for fluent use.
         """
-        it = self._create_other(creator, nominal_phases, num_terminals)
+        it = self._create_other(mrid, creator, nominal_phases, num_terminals)
         self._connect(self._current, it)
         action(it)
         self._current = it
@@ -313,28 +353,30 @@ class TestNetworkBuilder:
         self._connect(self.network.get(from_, ConductingEquipment), self.network.get(to, ConductingEquipment), from_terminal, to_terminal)
         return self
 
-    def add_feeder(self, head_mrid: str, sequence_number: Optional[int] = None) -> 'TestNetworkBuilder':
+    def add_feeder(self, head_mrid: str, sequence_number: Optional[int] = None, mrid: Optional[str] = None) -> 'TestNetworkBuilder':
         """
         Create a new feeder with the specified terminal as the head terminal.
 
         :param head_mrid: The mRID of the head `ConductingEquipment`.
         :param sequence_number: The `Terminal` sequence number of the head terminal. Defaults to last terminal.
+        :param mrid: Optional mRID for the new `Feeder`.
 
         :return: This `TestNetworkBuilder` to allow for fluent use.
         """
-        self._create_feeder(self.network.get(head_mrid, ConductingEquipment), sequence_number)
+        self._create_feeder(mrid, self.network.get(head_mrid, ConductingEquipment), sequence_number)
         return self
 
-    def add_lv_feeder(self, head_mrid: str, sequence_number: Optional[int] = None) -> 'TestNetworkBuilder':
+    def add_lv_feeder(self, head_mrid: str, sequence_number: Optional[int] = None, mrid: Optional[str] = None) -> 'TestNetworkBuilder':
         """
         Create a new LV feeder with the specified terminal as the head terminal.
 
         :param head_mrid: The mRID of the head `ConductingEquipment`.
         :param sequence_number: The `Terminal` sequence number of the head terminal. Defaults to last terminal.
+        :param mrid: Optional mRID for the new `LvFeeder`.
 
         :return: This `TestNetworkBuilder` to allow for fluent use.
         """
-        self._create_lv_feeder(self.network.get(head_mrid, ConductingEquipment), sequence_number)
+        self._create_lv_feeder(mrid, self.network.get(head_mrid, ConductingEquipment), sequence_number)
         return self
 
     async def build(self, apply_directions_from_sources: bool = True, assign_feeders: bool = True) -> NetworkService:
@@ -359,7 +401,10 @@ class TestNetworkBuilder:
 
         return self.network
 
-    def _next_id(self, type_: str) -> str:
+    def _next_id(self, mrid: Optional[str], type_: str) -> str:
+        if mrid:
+            return mrid
+
         id_ = f"{type_}{self._count}"
         self._count += 1
         return id_
@@ -371,26 +416,26 @@ class TestNetworkBuilder:
         )
         self._current_terminal = None
 
-    def _create_external_source(self, nominal_phases: PhaseCode) -> EnergySource:
+    def _create_external_source(self, mrid: Optional[str], nominal_phases: PhaseCode) -> EnergySource:
         if any(it not in PhaseCode.ABCN for it in nominal_phases.single_phases):
             raise ValueError("EnergySource phases must be a subset of ABCN")
 
-        es = EnergySource(mrid=self._next_id("s"), is_external_grid=True)
+        es = EnergySource(mrid=self._next_id(mrid, "s"), is_external_grid=True)
         self._add_terminal(es, 1, nominal_phases)
 
         self.network.add(es)
         return es
 
-    def _create_acls(self, nominal_phases: PhaseCode) -> AcLineSegment:
-        acls = AcLineSegment(mrid=self._next_id("c"))
+    def _create_acls(self, mrid: Optional[str], nominal_phases: PhaseCode) -> AcLineSegment:
+        acls = AcLineSegment(mrid=self._next_id(mrid, "c"))
         self._add_terminal(acls, 1, nominal_phases)
         self._add_terminal(acls, 2, nominal_phases)
 
         self.network.add(acls)
         return acls
 
-    def _create_breaker(self, nominal_phases: PhaseCode, is_normally_open: bool, is_open: bool) -> Breaker:
-        b = Breaker(mrid=self._next_id("b"))
+    def _create_breaker(self, mrid: Optional[str], nominal_phases: PhaseCode, is_normally_open: bool, is_open: bool) -> Breaker:
+        b = Breaker(mrid=self._next_id(mrid, "b"))
         b.set_normally_open(is_normally_open)
         b.set_open(is_open)
 
@@ -400,16 +445,16 @@ class TestNetworkBuilder:
         self.network.add(b)
         return b
 
-    def _create_junction(self, nominal_phases: PhaseCode, num_terminals: Optional[int]) -> Junction:
-        j = Junction(mrid=self._next_id("j"))
+    def _create_junction(self, mrid: Optional[str], nominal_phases: PhaseCode, num_terminals: Optional[int]) -> Junction:
+        j = Junction(mrid=self._next_id(mrid, "j"))
         for i in range(1, (num_terminals if num_terminals is not None else 2) + 1):
             self._add_terminal(j, i, nominal_phases)
 
         self.network.add(j)
         return j
 
-    def _create_power_transformer(self, nominal_phases: List[PhaseCode]):
-        tx = PowerTransformer(mrid=self._next_id("tx"))
+    def _create_power_transformer(self, mrid: Optional[str], nominal_phases: List[PhaseCode]):
+        tx = PowerTransformer(mrid=self._next_id(mrid, "tx"))
 
         i = 1
         for phase_code in nominal_phases:
@@ -431,20 +476,21 @@ class TestNetworkBuilder:
 
     def _create_other(
         self,
+        mrid: Optional[str],
         creator: Union[OtherCreator, Type[ConductingEquipment]],
         nominal_phases: PhaseCode,
         num_terminals: Optional[int]
     ) -> ConductingEquipment:
-        o = creator(mrid=self._next_id("o"))
+        o = creator(mrid=self._next_id(mrid, "o"))
         for i in range(1, (num_terminals if num_terminals is not None else 2) + 1):
             self._add_terminal(o, i, nominal_phases)
 
         self.network.add(o)
         return o
 
-    def _create_feeder(self, head_equipment: ConductingEquipment, sequence_number: Optional[int] = None) -> Feeder:
+    def _create_feeder(self, mrid: Optional[str], head_equipment: ConductingEquipment, sequence_number: Optional[int] = None) -> Feeder:
         f = Feeder(
-            mrid=self._next_id("fdr"),
+            mrid=self._next_id(mrid, "fdr"),
             normal_head_terminal=head_equipment.get_terminal_by_sn(sequence_number if sequence_number else head_equipment.num_terminals())
         )
 
@@ -454,9 +500,9 @@ class TestNetworkBuilder:
         self.network.add(f)
         return f
 
-    def _create_lv_feeder(self, head_equipment: ConductingEquipment, sequence_number: Optional[int] = None) -> LvFeeder:
+    def _create_lv_feeder(self, mrid: Optional[str], head_equipment: ConductingEquipment, sequence_number: Optional[int] = None) -> LvFeeder:
         lvf = LvFeeder(
-            mrid=self._next_id("lvf"),
+            mrid=self._next_id(mrid, "lvf"),
             normal_head_terminal=head_equipment.get_terminal_by_sn(sequence_number if sequence_number else head_equipment.num_terminals())
         )
 

--- a/test/cim/iec61970/base/core/test_phase_code.py
+++ b/test/cim/iec61970/base/core/test_phase_code.py
@@ -70,3 +70,29 @@ class TestPhaseCode:
 
     def test_for_each(self):
         assert list(PhaseCode.ABCN) == [SinglePhaseKind.A, SinglePhaseKind.B, SinglePhaseKind.C, SinglePhaseKind.N]
+
+    def test_plus(self):
+        assert PhaseCode.A + SinglePhaseKind.B == PhaseCode.AB
+        assert PhaseCode.BC + PhaseCode.AN == PhaseCode.ABCN
+        assert PhaseCode.X + SinglePhaseKind.Y == PhaseCode.XY
+        assert PhaseCode.N + PhaseCode.XY == PhaseCode.XYN
+
+        # Can add existing phases.
+        assert PhaseCode.ABCN + SinglePhaseKind.A == PhaseCode.ABCN
+        assert PhaseCode.ABCN + SinglePhaseKind.B == PhaseCode.ABCN
+        assert PhaseCode.A + PhaseCode.ABCN == PhaseCode.ABCN
+
+        # Returns NONE for invalid additions.
+        assert PhaseCode.ABCN + SinglePhaseKind.X == PhaseCode.NONE
+        assert PhaseCode.ABCN + PhaseCode.X == PhaseCode.NONE
+
+    def test_minus(self):
+        assert PhaseCode.ABCN - SinglePhaseKind.B == PhaseCode.ACN
+        assert PhaseCode.ABCN - PhaseCode.AN == PhaseCode.BC
+        assert PhaseCode.BC - SinglePhaseKind.C == PhaseCode.B
+        assert PhaseCode.XY - PhaseCode.X == PhaseCode.Y
+
+        assert PhaseCode.X - SinglePhaseKind.Y == PhaseCode.X
+        assert PhaseCode.AB - PhaseCode.C == PhaseCode.AB
+
+        assert PhaseCode.ABCN - PhaseCode.ABCN == PhaseCode.NONE

--- a/test/cim/iec61970/base/wires/test_single_phase_kind.py
+++ b/test/cim/iec61970/base/wires/test_single_phase_kind.py
@@ -6,13 +6,25 @@
 from zepben.protobuf.cim.iec61970.base.wires.SinglePhaseKind_pb2 import SinglePhaseKind as PBSinglePhaseKind
 
 from cim.enum_validator import validate_enum
-from zepben.evolve import SinglePhaseKind, single_phase_kind_by_id
+from zepben.evolve import SinglePhaseKind, single_phase_kind_by_id, PhaseCode
 
 
-def test_single_phase_kind_enum():
-    validate_enum(SinglePhaseKind, PBSinglePhaseKind)
+class TestSinglePhaseKind:
 
+    def test_single_phase_kind_enum(self):
+        validate_enum(SinglePhaseKind, PBSinglePhaseKind)
 
-def test_single_phase_kind_value_lookup():
-    for spc in SinglePhaseKind:
-        assert single_phase_kind_by_id(spc.value[0]) == spc, f"value lookup of {spc.name} resulted in {single_phase_kind_by_id(spc.value[0]).name}"
+    def test_single_phase_kind_value_lookup(self):
+        for spc in SinglePhaseKind:
+            assert single_phase_kind_by_id(spc.value[0]) == spc, f"value lookup of {spc.name} resulted in {single_phase_kind_by_id(spc.value[0]).name}"
+
+    def test_plus(self):
+        assert SinglePhaseKind.A + SinglePhaseKind.B == PhaseCode.AB
+        assert SinglePhaseKind.A + SinglePhaseKind.A == PhaseCode.A
+        assert SinglePhaseKind.A + PhaseCode.BC == PhaseCode.ABC
+
+    def test_minus(self):
+        assert SinglePhaseKind.B - SinglePhaseKind.A == PhaseCode.B
+        assert SinglePhaseKind.A - SinglePhaseKind.A == PhaseCode.NONE
+        assert SinglePhaseKind.A - PhaseCode.BC == PhaseCode.A
+        assert SinglePhaseKind.A - PhaseCode.ABC == PhaseCode.NONE

--- a/test/services/network/tracing/connectivity/test_terminal_connectivity_internal.py
+++ b/test/services/network/tracing/connectivity/test_terminal_connectivity_internal.py
@@ -30,6 +30,27 @@ class TestTerminalConnectivityInternal:
         self._validate_tx_paths(PhaseCode.XY, PhaseCode.AC)
         self._validate_tx_paths(PhaseCode.XY, PhaseCode.XY)
 
+    def test_paths_through_hv1_lv2_tx(self):
+        self._validate_tx_paths(PhaseCode.AB, PhaseCode.ABN)
+        self._validate_tx_paths(PhaseCode.AB, PhaseCode.BCN, PhaseCode.NONE)
+        self._validate_tx_paths(PhaseCode.AB, PhaseCode.ACN, PhaseCode.NONE)
+        self._validate_tx_paths(PhaseCode.AB, PhaseCode.XYN)
+
+        self._validate_tx_paths(PhaseCode.BC, PhaseCode.ABN, PhaseCode.NONE)
+        self._validate_tx_paths(PhaseCode.BC, PhaseCode.BCN)
+        self._validate_tx_paths(PhaseCode.BC, PhaseCode.ACN, PhaseCode.NONE)
+        self._validate_tx_paths(PhaseCode.BC, PhaseCode.XYN)
+
+        self._validate_tx_paths(PhaseCode.AC, PhaseCode.ABN, PhaseCode.NONE)
+        self._validate_tx_paths(PhaseCode.AC, PhaseCode.BCN, PhaseCode.NONE)
+        self._validate_tx_paths(PhaseCode.AC, PhaseCode.ACN)
+        self._validate_tx_paths(PhaseCode.AC, PhaseCode.XYN)
+
+        self._validate_tx_paths(PhaseCode.XY, PhaseCode.ABN)
+        self._validate_tx_paths(PhaseCode.XY, PhaseCode.ACN)
+        self._validate_tx_paths(PhaseCode.XY, PhaseCode.BCN)
+        self._validate_tx_paths(PhaseCode.XY, PhaseCode.XYN)
+
     def test_paths_through_hv1_lv1_tx(self):
         self._validate_tx_paths(PhaseCode.AB, PhaseCode.AN)
         self._validate_tx_paths(PhaseCode.AB, PhaseCode.BN, PhaseCode.NONE)
@@ -50,6 +71,41 @@ class TestTerminalConnectivityInternal:
         self._validate_tx_paths(PhaseCode.XY, PhaseCode.BN)
         self._validate_tx_paths(PhaseCode.XY, PhaseCode.CN)
         self._validate_tx_paths(PhaseCode.XY, PhaseCode.XN)
+
+    def test_paths_through_lv2_lv2_tx(self):
+        self._validate_tx_paths(PhaseCode.ABN, PhaseCode.ABN)
+        self._validate_tx_paths(PhaseCode.BCN, PhaseCode.BCN)
+        self._validate_tx_paths(PhaseCode.ACN, PhaseCode.ACN)
+
+        self._validate_tx_paths(PhaseCode.ABN, PhaseCode.XYN)
+        self._validate_tx_paths(PhaseCode.BCN, PhaseCode.XYN)
+        self._validate_tx_paths(PhaseCode.ACN, PhaseCode.XYN)
+
+        self._validate_tx_paths(PhaseCode.XYN, PhaseCode.ABN)
+        self._validate_tx_paths(PhaseCode.XYN, PhaseCode.BCN)
+        self._validate_tx_paths(PhaseCode.XYN, PhaseCode.ACN)
+        self._validate_tx_paths(PhaseCode.XYN, PhaseCode.XYN)
+
+    def test_paths_through_lv2_hv1_tx(self):
+        self._validate_tx_paths(PhaseCode.ABN, PhaseCode.AB)
+        self._validate_tx_paths(PhaseCode.ABN, PhaseCode.BC, PhaseCode.NONE)
+        self._validate_tx_paths(PhaseCode.ABN, PhaseCode.AC, PhaseCode.NONE)
+        self._validate_tx_paths(PhaseCode.ABN, PhaseCode.XY)
+
+        self._validate_tx_paths(PhaseCode.BCN, PhaseCode.AB, PhaseCode.NONE)
+        self._validate_tx_paths(PhaseCode.BCN, PhaseCode.BC)
+        self._validate_tx_paths(PhaseCode.BCN, PhaseCode.AC, PhaseCode.NONE)
+        self._validate_tx_paths(PhaseCode.BCN, PhaseCode.XY)
+
+        self._validate_tx_paths(PhaseCode.ACN, PhaseCode.AB, PhaseCode.NONE)
+        self._validate_tx_paths(PhaseCode.ACN, PhaseCode.BC, PhaseCode.NONE)
+        self._validate_tx_paths(PhaseCode.ACN, PhaseCode.AC)
+        self._validate_tx_paths(PhaseCode.ACN, PhaseCode.XY)
+
+        self._validate_tx_paths(PhaseCode.XYN, PhaseCode.AB)
+        self._validate_tx_paths(PhaseCode.XYN, PhaseCode.BC)
+        self._validate_tx_paths(PhaseCode.XYN, PhaseCode.AC)
+        self._validate_tx_paths(PhaseCode.XYN, PhaseCode.XY)
 
     def test_paths_through_lv1_hv1_tx(self):
         self._validate_tx_paths(PhaseCode.AN, PhaseCode.AB)
@@ -155,6 +211,48 @@ class TestTerminalConnectivityInternal:
         self._validate_tx_paths(PhaseCode.XN, PhaseCode.B)
         self._validate_tx_paths(PhaseCode.XN, PhaseCode.C)
         self._validate_tx_paths(PhaseCode.XN, PhaseCode.X)
+
+    def test_paths_through_swer_lv2_tx(self):
+        self._validate_tx_paths(PhaseCode.A, PhaseCode.ABN)
+        self._validate_tx_paths(PhaseCode.A, PhaseCode.BCN, PhaseCode.NONE)
+        self._validate_tx_paths(PhaseCode.A, PhaseCode.ACN, PhaseCode.NONE)
+        self._validate_tx_paths(PhaseCode.A, PhaseCode.XYN)
+
+        self._validate_tx_paths(PhaseCode.B, PhaseCode.ABN, PhaseCode.NONE)
+        self._validate_tx_paths(PhaseCode.B, PhaseCode.BCN)
+        self._validate_tx_paths(PhaseCode.B, PhaseCode.ACN, PhaseCode.NONE)
+        self._validate_tx_paths(PhaseCode.B, PhaseCode.XYN)
+
+        self._validate_tx_paths(PhaseCode.C, PhaseCode.ABN, PhaseCode.NONE)
+        self._validate_tx_paths(PhaseCode.C, PhaseCode.BCN, PhaseCode.NONE)
+        self._validate_tx_paths(PhaseCode.C, PhaseCode.ACN)
+        self._validate_tx_paths(PhaseCode.C, PhaseCode.XYN)
+
+        self._validate_tx_paths(PhaseCode.X, PhaseCode.ABN)
+        self._validate_tx_paths(PhaseCode.X, PhaseCode.BCN)
+        self._validate_tx_paths(PhaseCode.X, PhaseCode.ACN)
+        self._validate_tx_paths(PhaseCode.X, PhaseCode.XYN)
+
+    def test_paths_through_lv2_swer_tx(self):
+        self._validate_tx_paths(PhaseCode.ABN, PhaseCode.A)
+        self._validate_tx_paths(PhaseCode.ABN, PhaseCode.B, PhaseCode.NONE)
+        self._validate_tx_paths(PhaseCode.ABN, PhaseCode.C, PhaseCode.NONE)
+        self._validate_tx_paths(PhaseCode.ABN, PhaseCode.X)
+
+        self._validate_tx_paths(PhaseCode.BCN, PhaseCode.A, PhaseCode.NONE)
+        self._validate_tx_paths(PhaseCode.BCN, PhaseCode.B)
+        self._validate_tx_paths(PhaseCode.BCN, PhaseCode.C, PhaseCode.NONE)
+        self._validate_tx_paths(PhaseCode.BCN, PhaseCode.X)
+
+        self._validate_tx_paths(PhaseCode.ACN, PhaseCode.A, PhaseCode.NONE)
+        self._validate_tx_paths(PhaseCode.ACN, PhaseCode.B, PhaseCode.NONE)
+        self._validate_tx_paths(PhaseCode.ACN, PhaseCode.C)
+        self._validate_tx_paths(PhaseCode.ACN, PhaseCode.X)
+
+        self._validate_tx_paths(PhaseCode.XYN, PhaseCode.A)
+        self._validate_tx_paths(PhaseCode.XYN, PhaseCode.B)
+        self._validate_tx_paths(PhaseCode.XYN, PhaseCode.C)
+        self._validate_tx_paths(PhaseCode.XYN, PhaseCode.X)
 
     def _validate_tx_paths(self, primary: PhaseCode, secondary: PhaseCode, traced: PhaseCode = None):
         traced = traced or secondary

--- a/test/services/network/tracing/phases/test_set_phases.py
+++ b/test/services/network/tracing/phases/test_set_phases.py
@@ -47,13 +47,13 @@ async def test_applies_phases_from_sources():
     """
     network_service = await (
         TestNetworkBuilder()
-            .from_source(PhaseCode.ABCN)  # s0
-            .to_acls(PhaseCode.ABCN)  # c1
-            .to_acls(PhaseCode.ABCN)  # c2
-            .branch_from("c1")
-            .to_acls(PhaseCode.AB)  # c3
-            .from_acls(PhaseCode.ABCN)  # c4
-            .build()
+        .from_source(PhaseCode.ABCN)  # s0
+        .to_acls(PhaseCode.ABCN)  # c1
+        .to_acls(PhaseCode.ABCN)  # c2
+        .branch_from("c1")
+        .to_acls(PhaseCode.AB)  # c3
+        .from_acls(PhaseCode.ABCN)  # c4
+        .build()
     )
     await connected_equipment_trace_with_logging(network_service.objects(EnergySource))
 
@@ -73,13 +73,13 @@ async def test_stops_at_open_points():
     """
     network_service = await (
         TestNetworkBuilder()
-            .from_source(PhaseCode.ABCN)  # s0
-            .to_breaker(PhaseCode.ABCN, is_normally_open=True, is_open=False)  # b1
-            .to_acls(PhaseCode.ABCN)  # c2
-            .from_source(PhaseCode.ABCN)  # s3
-            .to_breaker(PhaseCode.ABCN, is_open=True)  # b4
-            .to_acls(PhaseCode.ABCN)  # c5
-            .build()
+        .from_source(PhaseCode.ABCN)  # s0
+        .to_breaker(PhaseCode.ABCN, is_normally_open=True, is_open=False)  # b1
+        .to_acls(PhaseCode.ABCN)  # c2
+        .from_source(PhaseCode.ABCN)  # s3
+        .to_breaker(PhaseCode.ABCN, is_open=True)  # b4
+        .to_acls(PhaseCode.ABCN)  # c5
+        .build()
     )
     await connected_equipment_trace_with_logging(network_service.objects(EnergySource))
 
@@ -107,10 +107,10 @@ async def test_traces_unganged():
 
     network_service = await (
         TestNetworkBuilder()
-            .from_source(PhaseCode.ABCN)  # s0
-            .to_breaker(PhaseCode.ABCN, action=set_open_status)  # b1
-            .to_acls(PhaseCode.ABCN)
-            .build()
+        .from_source(PhaseCode.ABCN)  # s0
+        .to_breaker(PhaseCode.ABCN, action=set_open_status)  # b1
+        .to_acls(PhaseCode.ABCN)
+        .build()
     )
     await connected_equipment_trace_with_logging(network_service.objects(EnergySource))
 
@@ -128,10 +128,10 @@ async def test_can_run_from_terminal():
     """
     network_service = await (
         TestNetworkBuilder()
-            .from_acls(PhaseCode.ABCN)  # c0
-            .to_acls(PhaseCode.ABCN)  # c1
-            .to_acls(PhaseCode.ABCN)  # c2
-            .build()
+        .from_acls(PhaseCode.ABCN)  # c0
+        .to_acls(PhaseCode.ABCN)  # c1
+        .to_acls(PhaseCode.ABCN)  # c2
+        .build()
     )
     await connected_equipment_trace_with_logging(network_service.objects(EnergySource))
 
@@ -149,9 +149,9 @@ async def test_must_provide_the_correct_number_of_phases():
     """
     network_service = await (
         TestNetworkBuilder()
-            .from_acls(PhaseCode.A)  # c0
-            .to_acls(PhaseCode.A)  # c1
-            .build()
+        .from_acls(PhaseCode.A)  # c0
+        .to_acls(PhaseCode.A)  # c1
+        .build()
     )
     await connected_equipment_trace_with_logging(network_service.objects(EnergySource))
 
@@ -169,9 +169,9 @@ async def test_detects_cross_phasing_flow():
     """
     network_service = await (
         TestNetworkBuilder()
-            .from_acls(PhaseCode.A, _set_normal_phase(1, SPK.A, SPK.A))
-            .to_acls(PhaseCode.A, _set_normal_phase(1, SPK.A, SPK.B))
-            .build()
+        .from_acls(PhaseCode.A, action=_set_normal_phase(1, SPK.A, SPK.A))
+        .to_acls(PhaseCode.A, action=_set_normal_phase(1, SPK.A, SPK.B))
+        .build()
     )
     await connected_equipment_trace_with_logging(network_service.objects(EnergySource))
 
@@ -192,10 +192,10 @@ async def test_detects_cross_phasing_connected():
     """
     network_service = await (
         TestNetworkBuilder()
-            .from_acls(PhaseCode.A, _set_normal_phase(1, SPK.A, SPK.A))
-            .to_acls(PhaseCode.A)
-            .to_acls(PhaseCode.A, _set_normal_phase(0, SPK.A, SPK.B))
-            .build()
+        .from_acls(PhaseCode.A, action=_set_normal_phase(1, SPK.A, SPK.A))
+        .to_acls(PhaseCode.A)
+        .to_acls(PhaseCode.A, action=_set_normal_phase(0, SPK.A, SPK.B))
+        .build()
     )
     await connected_equipment_trace_with_logging(network_service.objects(EnergySource))
 
@@ -219,12 +219,12 @@ async def test_can_back_trace_through_xn_xy_transformer_loop():
     """
     network_service = await (
         TestNetworkBuilder()
-            .from_source(PhaseCode.ABC)  # s0
-            .to_power_transformer([PhaseCode.XY, PhaseCode.XN])  # tx1
-            .to_acls(PhaseCode.XN)  # c2
-            .to_power_transformer([PhaseCode.XN, PhaseCode.XY])  # tx3
-            .connect("tx3", "s0", 2, 1)
-            .build()
+        .from_source(PhaseCode.ABC)  # s0
+        .to_power_transformer([PhaseCode.XY, PhaseCode.XN])  # tx1
+        .to_acls(PhaseCode.XN)  # c2
+        .to_power_transformer([PhaseCode.XN, PhaseCode.XY])  # tx3
+        .connect("tx3", "s0", 2, 1)
+        .build()
     )
     await connected_equipment_trace_with_logging(network_service.objects(EnergySource))
 
@@ -241,11 +241,11 @@ async def test_can_back_trace_through_xn_xy_transformer_spur():
     """
     network_service = await (
         TestNetworkBuilder()
-            .from_source(PhaseCode.ABC)  # s0
-            .to_power_transformer([PhaseCode.XY, PhaseCode.XN])  # tx1
-            .to_acls(PhaseCode.XN)  # c2
-            .to_power_transformer([PhaseCode.XN, PhaseCode.XY])  # tx3
-            .build()
+        .from_source(PhaseCode.ABC)  # s0
+        .to_power_transformer([PhaseCode.XY, PhaseCode.XN])  # tx1
+        .to_acls(PhaseCode.XN)  # c2
+        .to_power_transformer([PhaseCode.XN, PhaseCode.XY])  # tx3
+        .build()
     )
 
     validate_phases_from_term_or_equip(network_service, "s0", PhaseCode.ABC)

--- a/test/testing/test_test_network_builder.py
+++ b/test/testing/test_test_network_builder.py
@@ -152,6 +152,38 @@ class TestTestNetworkBuilder:
         self._validate_ends(n, "tx3", [PhaseCode.AB, PhaseCode.AB, PhaseCode.AN])
 
     @pytest.mark.asyncio
+    async def test_can_override_ids(self):
+        ns = await (TestNetworkBuilder()
+                    .from_source(mrid="my source 1")
+                    .to_source(mrid="my source 2")
+                    .from_acls(mrid="my acls 1")
+                    .to_acls(mrid="my acls 2")
+                    .from_breaker(mrid="my breaker 1")
+                    .to_breaker(mrid="my breaker 2")
+                    .from_junction(mrid="my junction 1")
+                    .to_junction(mrid="my junction 2")
+                    .from_power_transformer(mrid="my tx 1")
+                    .to_power_transformer(mrid="my tx 2")
+                    .from_other(Fuse, mrid="my other 1")
+                    .to_other(Fuse, mrid="my other 2")
+                    .build())
+
+        assert {it.mrid for it in ns.objects(ConductingEquipment)} == {
+            "my source 1",
+            "my source 2",
+            "my acls 1",
+            "my acls 2",
+            "my breaker 1",
+            "my breaker 2",
+            "my junction 1",
+            "my junction 2",
+            "my tx 1",
+            "my tx 2",
+            "my other 1",
+            "my other 2"
+        }
+
+    @pytest.mark.asyncio
     async def test_can_start_with_open_points(self):
         #
         # 1 b0 2

--- a/test/testing/test_test_network_builder.py
+++ b/test/testing/test_test_network_builder.py
@@ -3,13 +3,14 @@
 #  This Source Code Form is subject to the terms of the Mozilla Public
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at https:#mozilla.org/MPL/2.0/.
+from collections import Counter
 from typing import Callable, List
 
 import pytest
 from pytest import raises
 
 from zepben.evolve import PhaseCode, PowerTransformerEnd, Terminal, NetworkService, ConductingEquipment, Breaker, Feeder, PowerTransformer, \
-    connected_terminals, TestNetworkBuilder, Fuse, LvFeeder
+    connected_terminals, TestNetworkBuilder, Fuse, LvFeeder, ConnectivityNode
 
 
 class TestTestNetworkBuilder:
@@ -306,6 +307,7 @@ class TestTestNetworkBuilder:
             assert mrid == "o1"
             return Fuse(mrid="my-id")
 
+        # noinspection PyTypeChecker
         n = await (TestNetworkBuilder()
                    .from_other(Fuse, num_terminals=1)  # o0
                    .to_other(replace_o1, num_terminals=1)  # my-id[o1]
@@ -318,6 +320,16 @@ class TestTestNetworkBuilder:
         self._validate_connections(n, "my-id", [["o0-t1"]])
         self._validate_connections(n, "o2", [[], ["o3-t1"]])
         self._validate_connections(n, "o3", [["o2-t2"], []])
+
+    def test_can_choose_the_connectivity_node_id(self):
+        self._validate_connectivity_node_override(lambda b, mrid, cn_mrid: b.to_breaker(mrid=mrid, connectivity_node_mrid=cn_mrid))
+        self._validate_connectivity_node_override(lambda b, mrid, cn_mrid: b.to_junction(mrid=mrid, connectivity_node_mrid=cn_mrid))
+        self._validate_connectivity_node_override(lambda b, mrid, cn_mrid: b.to_acls(mrid=mrid, connectivity_node_mrid=cn_mrid))
+        self._validate_connectivity_node_override(lambda b, mrid, cn_mrid: b.to_power_transformer(mrid=mrid, connectivity_node_mrid=cn_mrid))
+        self._validate_connectivity_node_override(lambda b, mrid, cn_mrid: b.to_power_electronics_connection(mrid=mrid, connectivity_node_mrid=cn_mrid))
+        self._validate_connectivity_node_override(lambda b, mrid, cn_mrid: b.to_energy_consumer(mrid=mrid, connectivity_node_mrid=cn_mrid))
+        self._validate_connectivity_node_override(lambda b, mrid, cn_mrid: b.to_source(mrid=mrid, connectivity_node_mrid=cn_mrid))
+        self._validate_connectivity_node_override(lambda b, mrid, cn_mrid: b.to_other(Fuse, mrid=mrid, connectivity_node_mrid=cn_mrid))
 
     def _validate_connections(self, n: NetworkService, mrid: str, expected_terms: List[List[str]]):
         assert n.get(mrid, ConductingEquipment).num_terminals() == len(expected_terms)
@@ -355,3 +367,31 @@ class TestTestNetworkBuilder:
 
         for end, terminal in zip(tx.ends, tx.terminals):
             assert end.terminal == terminal
+
+    @staticmethod
+    def _validate_connectivity_node_override(add_with_connectivity_node: Callable[[TestNetworkBuilder, str, str], None]):
+        builder = TestNetworkBuilder()
+        ns = builder.network
+
+        builder.from_source()  # s0
+        # Connect using a specific connectivity node
+        add_with_connectivity_node(builder, "my1", "specified-cn")
+        builder.from_acls()  # c1
+        # Reuse the specific connectivity node, which should connect all 4 items.
+        add_with_connectivity_node(builder, "my2", "specified-cn")
+        builder.from_acls()  # c2
+        builder.from_acls()  # c3
+        # Force connect to the specific connectivity node, which should connect the additional 2 items.
+        builder.connect("c2", "c3", 2, 1, "specified-cn")
+        builder.from_acls()  # c4
+        # Force connect using a different connectivity node, which should be overridden due to the `to` terminal being connected.
+        builder.connect("c2", "c4", 2, 1, "different-cn")
+        builder.from_acls()  # c5
+        # Force connect using a different connectivity node, which should be overridden due to the `from` terminal being connected.
+        builder.connect("c5", "c4", 2, 1, "different-cn")
+
+        assert Counter([it.mrid for it in ns.get("specified-cn", ConnectivityNode).terminals]) == \
+               Counter(["s0-t1", "my1-t1", "c1-t2", "my2-t1", "c2-t2", "c3-t1", "c4-t1", "c5-t2"])
+
+        # Make sure our overridden connectivity node was not created.
+        assert ns.get("different-cn", ConnectivityNode, default=None) is None

--- a/test/testing/test_test_network_builder.py
+++ b/test/testing/test_test_network_builder.py
@@ -162,8 +162,10 @@ class TestTestNetworkBuilder:
                     .to_breaker(mrid="my breaker 2")
                     .from_junction(mrid="my junction 1")
                     .to_junction(mrid="my junction 2")
+                    .to_power_electronics_connection(mrid="my pec 1")
                     .from_power_transformer(mrid="my tx 1")
                     .to_power_transformer(mrid="my tx 2")
+                    .to_energy_consumer(mrid="my ec 1")
                     .from_other(Fuse, mrid="my other 1")
                     .to_other(Fuse, mrid="my other 2")
                     .build())
@@ -177,8 +179,10 @@ class TestTestNetworkBuilder:
             "my breaker 2",
             "my junction 1",
             "my junction 2",
+            "my pec 1",
             "my tx 1",
             "my tx 2",
+            "my ec 1",
             "my other 1",
             "my other 2"
         }


### PR DESCRIPTION
# Description

* Added support for LV2 below SWER transformers.
* Improved logging when saving a database.
* The `TestNetworkBuilder` has been enhanced with the following features:
    * You can now set the ID's without having to create a customer 'other' creator.
    * Added inbuilt support for `EnergyConsumer`
    * The `to*` and `connect` functions can specify the connectivity node mRID to use.
* `Traversal` has two new helper methods:
    * `if_not_stopping`: Adds a step action that is only called if the traversal is not stopping on the item.
    * `if_stopping`: Adds a step action that is only called if the traversal is stopping on the item.
* `SetDirection.run(NetworkService)` will no longer set directions for feeders with a head terminal on an open switch.
* Feeder directions are now stopped at substation transformers in the same way as assigning equipment

# Checklist:

These are always required, if you do not do them, reviewers will be angry:
- [x] I have performed a self review of my own code.
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.

These you can remove from the list if they are not applicable for this PR.
- [x] I have updated the changelog.
- [x] I have updated any documentation required for these changes.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have considered if this is a breaking change and have communicated it with other team members if so.
