### PR TITLE
EWB-2452 Verify gRPC connections at channel creation time

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <option name="LINE_SEPARATOR" value="&#10;" />
     <option name="RIGHT_MARGIN" value="160" />
     <JSCodeStyleSettings version="0">
       <option name="SPACES_WITHIN_OBJECT_LITERAL_BRACES" value="true" />

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,3 +82,8 @@ to prevent the test from timing out while you step through the code:
    * Verify that all the tests are passing. 
 1. Update release notes in [```changelog.md```](changelog.md).
 1. Update _nio_type_to_cim in network_consumer.py to include newly added classes.
+
+## Adding support for new services ##
+
+Include new grpc services in the list of services ```GrpcChannelBuilder._test_connection()``` uses when attempting to confirm the connectivity of newly created
+grpc channels.

--- a/changelog.md
+++ b/changelog.md
@@ -1,13 +1,15 @@
 # Zepben Python SDK
 ## [0.38.0] - UNRELEASED
 ### Breaking Changes
-* None.
+* `connect_with_secret()` and `connect_with_password()` will no longer create a `ZepbenTokenFetcher` directly from kwargs.
 
 ### New Features
-* None.
+* Added support for `getMetadata()` gRPC calls on `CustomerConsumerClient`, `DiagramConsumerClient`, and `NetworkConsumerClient`.
 
 ### Enhancements
-* None.
+* `GrpcChannelBuilder` tests the connectivity of newly created channels before returning them to the user. This is done by calling `getMetadata()` against all
+known services, the channel is returned after the first successful response. Any connectivity errors will be propagated to the user. If no connectivity errors
+are encountered but no successful response is received from the known services, a `GrpcConnectionException` is thrown.
 
 ### Fixes
 * `SetDirection` now traces through non-substation transformers.
@@ -15,9 +17,9 @@
 ### Notes
 * None.
 
-## [0.37.0] - UNRELEASED
+## [0.37.0] - 2023-11-14
 ### Breaking Changes
-* * Updated to evolve-grpc 0.26.0.
+* Updated to evolve-grpc 0.26.0.
 
 ### New Features
 * PowerTransformerEnd now supports multiple ratings based on cooling types attached to the transformer. Use new `add_rating` and `get_rating` methods.

--- a/src/zepben/evolve/streaming/exceptions.py
+++ b/src/zepben/evolve/streaming/exceptions.py
@@ -4,10 +4,10 @@
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-__all__ = ["StreamingException", "UnsupportedOperationException"]
+__all__ = ["GrpcConnectionException", "UnsupportedOperationException"]
 
 
-class StreamingException(Exception):
+class GrpcConnectionException(IOError):
     pass
 
 

--- a/test/streaming/grpc/test_connect.py
+++ b/test/streaming/grpc/test_connect.py
@@ -87,20 +87,6 @@ def test_connect_with_secret_defaults(mocked_create_token_fetcher, _):
 
 
 @mock.patch("zepben.evolve.streaming.grpc.connect.GrpcChannelBuilder", return_value=base_gcb)
-@mock.patch("zepben.evolve.streaming.grpc.connect.ZepbenTokenFetcher", return_value=token_fetcher)
-def test_connect_with_secret_with_known_token_fetcher_config(mocked_zepben_token_fetcher, _):
-    assert connect_with_secret("client_id", "client_secret", host="host", rpc_port=1234, audience="audience",
-                               issuer_domain="issuer_domain") is authenticated_channel
-    assert token_fetcher.token_request_data == {
-        "client_id": "client_id",
-        "client_secret": "client_secret",
-        "grant_type": "client_credentials"
-    }
-
-    mocked_zepben_token_fetcher.assert_called_once_with(audience="audience", issuer_domain="issuer_domain")
-
-
-@mock.patch("zepben.evolve.streaming.grpc.connect.GrpcChannelBuilder", return_value=base_gcb)
 @mock.patch("zepben.evolve.streaming.grpc.connect.create_token_fetcher", return_value=token_fetcher)
 def test_connect_with_password(mocked_create_token_fetcher, _):
     assert connect_with_password("client_id", "username", "password", "host", 1234, "conf_address", False, "auth_ca.cert", "ca.cert") is authenticated_channel
@@ -136,18 +122,3 @@ def test_connect_with_password_defaults(mocked_create_token_fetcher, _):
     }
 
     mocked_create_token_fetcher.assert_called_once_with(conf_address="https://host/ewb/auth", verify_conf=True, verify_auth=True)
-
-
-@mock.patch("zepben.evolve.streaming.grpc.connect.GrpcChannelBuilder", return_value=base_gcb)
-@mock.patch("zepben.evolve.streaming.grpc.connect.ZepbenTokenFetcher", return_value=token_fetcher)
-def test_connect_with_password_with_known_token_fetcher_config(mocked_zepben_token_fetcher, _):
-    assert connect_with_password("client_id", "username", "password", "host", 1234, audience="audience", issuer_domain="issuer_domain") is authenticated_channel
-    assert token_fetcher.token_request_data == {
-        "client_id": "client_id",
-        "username": "username",
-        "password": "password",
-        "grant_type": "password",
-        "scope": "offline_access"
-    }
-
-    mocked_zepben_token_fetcher.assert_called_once_with(audience="audience", issuer_domain="issuer_domain")

--- a/test/streaming/grpc/test_grpc_channel_builder.py
+++ b/test/streaming/grpc/test_grpc_channel_builder.py
@@ -3,14 +3,17 @@ from unittest.mock import call
 
 import pytest
 from dataclassy import dataclass
+from grpc._channel import _InactiveRpcError, _RPCState
+from grpc._cython.cygrpc import OperationType
+from grpc import StatusCode, insecure_channel
 from zepben.auth import ZepbenTokenFetcher
+from zepben.protobuf.metadata.metadata_requests_pb2 import GetMetadataRequest
 
-from zepben.evolve import GrpcChannelBuilder
+from zepben.evolve import GrpcChannelBuilder, GrpcConnectionException
 
 
 @dataclass
 class MockReadable:
-
     contents: bytes
 
     def __enter__(self):
@@ -23,21 +26,62 @@ class MockReadable:
         return self.contents
 
 
+@dataclass
+class MockedChannel:
+    """
+    Mocked `grpc.insecure_channel`/`secure_channel` returns this class to represent the sync channel to be passed to `_test_connection()` rather than just a
+    string like the mocked `grpc.aio.insecure_channel` because we call `close()` on the sync channel inside `build()` after we are finished testing with it.
+    """
+    name: str
+
+    def close(self):
+        pass
+
+
+@mock.patch("zepben.evolve.GrpcChannelBuilder._test_connection")
 @mock.patch("grpc.aio.insecure_channel", return_value="insecure channel")
-def test_for_address(mock_insecure_channel):
+def test_skip_connection_test(mock_insecure_channel, mock_test_connection):
+    assert GrpcChannelBuilder().build(skip_connection_test=True) == "insecure channel"
+
+    mock_insecure_channel.assert_called_once_with('localhost:50051')
+    mock_test_connection.assert_not_called()
+
+
+@mock.patch("grpc.insecure_channel", return_value=MockedChannel('insecure sync test channel'))
+@mock.patch("zepben.evolve.GrpcChannelBuilder._test_connection")
+@mock.patch("grpc.aio.insecure_channel", return_value="insecure channel")
+def test_debug_connection_test(mock_insecure_channel, mock_test_connection, mock_insecure_sync_channel):
+    assert GrpcChannelBuilder().build(debug=True) == "insecure channel"
+
+    mock_insecure_sync_channel.assert_called_once_with("localhost:50051")
+    mock_test_connection.assert_called_once_with(MockedChannel('insecure sync test channel'), debug=True)
+    mock_insecure_channel.assert_called_once_with('localhost:50051')
+
+
+@mock.patch("grpc.insecure_channel", return_value=MockedChannel('insecure sync test channel'))
+@mock.patch("zepben.evolve.GrpcChannelBuilder._test_connection")
+@mock.patch("grpc.aio.insecure_channel", return_value="insecure channel")
+def test_for_address(mock_insecure_channel, mock_test_connection, mock_insecure_sync_channel):
     assert GrpcChannelBuilder().for_address("hostname", 1234).build() == "insecure channel"
 
+    mock_insecure_sync_channel.assert_called_once_with("hostname:1234")
+    mock_test_connection.assert_called_once_with(MockedChannel('insecure sync test channel'), debug=False)
     mock_insecure_channel.assert_called_once_with("hostname:1234")
 
 
+@mock.patch("grpc.secure_channel", return_value=MockedChannel("secure sync test channel"))
+@mock.patch("zepben.evolve.GrpcChannelBuilder._test_connection")
 @mock.patch("grpc.ssl_channel_credentials", return_value="channel creds")
 @mock.patch("grpc.aio.secure_channel", return_value="secure channel")
-def test_make_secure(mocked_secure_channel, mocked_ssl_channel_creds):
+def test_make_secure(mocked_secure_channel, mocked_ssl_channel_creds, mock_test_connection, mock_secure_sync_channel):
     assert GrpcChannelBuilder().for_address("hostname", 1234).make_secure_with_bytes(b"ca", b"cc", b"pk").build() == "secure channel"
     assert GrpcChannelBuilder().for_address("hostname", 1234).make_secure_with_bytes().build() == "secure channel"
 
     mocked_ssl_channel_creds.assert_has_calls([call(b"ca", b"pk", b"cc"), call(None, None, None)])
     mocked_secure_channel.assert_called_with("hostname:1234", "channel creds")
+    mock_secure_sync_channel.assert_called_with("hostname:1234", "channel creds")
+    mock_test_connection.assert_has_calls(
+        [call(MockedChannel("secure sync test channel"), debug=False), call(MockedChannel("secure sync test channel"), debug=False)])
 
 
 @mock.patch("builtins.open", side_effect=lambda filename, *args, **kwargs: MockReadable(str.encode(filename)))
@@ -50,19 +94,143 @@ def test_make_secure_filename_version(mocked_mswb, mocked_open):
     mocked_mswb.assert_has_calls([call(b"ca", b"cc", b"pk"), call(None, None, None)])
 
 
+@mock.patch("grpc.secure_channel", return_value=MockedChannel("secure sync test channel"))
+@mock.patch("zepben.evolve.GrpcChannelBuilder._test_connection")
 @mock.patch("grpc.aio.secure_channel")
 @mock.patch("grpc.composite_channel_credentials", return_value="composite creds")
 @mock.patch("grpc.metadata_call_credentials", return_value="call creds")
 @mock.patch("grpc.ssl_channel_credentials", return_value="ssl creds")
-def test_with_token_fetcher(mocked_ssl_channel_creds, mocked_md_call_creds, mocked_comp_channel_creds, mocked_secure_channel):
-    GrpcChannelBuilder().for_address("hostname", 1234).make_secure().with_token_fetcher(ZepbenTokenFetcher("audience", "issuer_domain")).build()
+def test_with_token_fetcher(mocked_ssl_channel_creds, mocked_md_call_creds, mocked_comp_channel_creds, mocked_secure_channel, mock_test_connection,
+                            mock_secure_sync_channel):
+    GrpcChannelBuilder().for_address("hostname", 1234).make_secure().with_token_fetcher(
+        ZepbenTokenFetcher("audience", "issuer_domain")).build()
 
     mocked_ssl_channel_creds.assert_called_once()
     mocked_md_call_creds.assert_called_once()
     mocked_comp_channel_creds.assert_called_once_with("ssl creds", "call creds")
     mocked_secure_channel.assert_called_once_with("hostname:1234", "composite creds")
+    mock_secure_sync_channel.assert_called_once_with("hostname:1234", "composite creds")
+    mock_test_connection.assert_called_once_with(MockedChannel('secure sync test channel'), debug=False)
 
 
 def test_with_token_fetcher_before_make_secure():
     with pytest.raises(Exception, match="You must call make_secure before calling with_token_fetcher."):
         GrpcChannelBuilder().with_token_fetcher(ZepbenTokenFetcher("audience", "issuer_domain"))
+
+
+@mock.patch("grpc._channel._UnaryUnaryMultiCallable.__call__",
+            side_effect=[
+                _InactiveRpcError(_RPCState(
+                    [OperationType.send_message],
+                    None,
+                    None,
+                    StatusCode.UNIMPLEMENTED,
+                    "details"
+                )),
+                "metadata response",
+                Exception("Exception2")
+            ])
+def test_test_connection_returns_on_first_response(mock_getMetadata):
+    channel = insecure_channel("unused")
+    GrpcChannelBuilder()._test_connection(channel, False)
+
+    mock_getMetadata.assert_has_calls([call(GetMetadataRequest(), wait_for_ready=False),
+                                       call(GetMetadataRequest(), wait_for_ready=False)], any_order=False)
+    assert mock_getMetadata.call_count == 2
+
+
+@mock.patch("grpc._channel._UnaryUnaryMultiCallable.__call__", side_effect=[
+    _InactiveRpcError(_RPCState(
+        [OperationType.send_message],
+        None,
+        None,
+        StatusCode.UNAVAILABLE,
+        "details",
+    ))
+    ,
+    Exception("Exception1"),
+    Exception("Exception2")
+])
+def test_test_connection_raises_on_first_unavailable(mock_getMetadata):
+    channel = insecure_channel("unused")
+    with pytest.raises(_InactiveRpcError, match='<_InactiveRpcError of RPC that terminated with:\n\tstatus = StatusCode.UNAVAILABLE\n\tdetails = '
+                                                '"details"\n\tdebug_error_string = "None"\n>'):
+        GrpcChannelBuilder()._test_connection(channel, False)
+    mock_getMetadata.assert_called_once()
+
+
+@mock.patch("grpc._channel._UnaryUnaryMultiCallable.__call__", side_effect=[
+    _InactiveRpcError(_RPCState(
+        [OperationType.send_message],
+        None,
+        None,
+        StatusCode.DATA_LOSS,
+        "details",
+    )),
+    _InactiveRpcError(_RPCState(
+        [OperationType.send_message],
+        None,
+        None,
+        StatusCode.DEADLINE_EXCEEDED,
+        "details1",
+    )),
+    _InactiveRpcError(_RPCState(
+        [OperationType.send_message],
+        None,
+        None,
+        StatusCode.RESOURCE_EXHAUSTED,
+        "details2",
+    ))
+])
+def test_test_connection_raises_connection_exception(mock_getMetadata):
+    channel = insecure_channel("unused")
+    with pytest.raises(GrpcConnectionException, match="Couldn't establish gRPC connection to any service on myServer.myDomain:9999.\n"):
+        GrpcChannelBuilder().for_address("myServer.myDomain", 9999)._test_connection(channel, False)
+    mock_getMetadata.assert_has_calls(
+        [call(GetMetadataRequest(), wait_for_ready=False),
+         call(GetMetadataRequest(), wait_for_ready=False),
+         call(GetMetadataRequest(), wait_for_ready=False)]
+    )
+    assert mock_getMetadata.call_count == 3
+
+
+@mock.patch("grpc._channel._UnaryUnaryMultiCallable.__call__", side_effect=[
+    _InactiveRpcError(_RPCState(
+        [OperationType.send_message],
+        None,
+        None,
+        StatusCode.DATA_LOSS,
+        "details1",
+    )),
+    _InactiveRpcError(_RPCState(
+        [OperationType.send_message],
+        None,
+        None,
+        StatusCode.DEADLINE_EXCEEDED,
+        "details2",
+    )),
+    _InactiveRpcError(_RPCState(
+        [OperationType.send_message],
+        None,
+        None,
+        StatusCode.RESOURCE_EXHAUSTED,
+        "details3",
+    ))
+])
+def test_test_connection_raises_connection_exception_with_debug(mock_getMetadata):
+    channel = insecure_channel("unused")
+    with pytest.raises(GrpcConnectionException,
+                       match='Couldn\'t establish gRPC connection to any service on myServer.myDomain:9999.\n'
+                             'Received the following exception with NetworkConsumerStub:\n<_InactiveRpcError of RPC that terminated with:\n'
+                             '\tstatus = StatusCode.DATA_LOSS\n\tdetails = "details1"\n\tdebug_error_string = "None"\n>\n'
+                             'Received the following exception with DiagramConsumerStub:\n<_InactiveRpcError of RPC that terminated with:\n'
+                             '\tstatus = StatusCode.DEADLINE_EXCEEDED\n\tdetails = "details2"\n\tdebug_error_string = "None"\n>\n'
+                             'Received the following exception with CustomerConsumerStub:\n<_InactiveRpcError of RPC that terminated with:\n'
+                             '\tstatus = StatusCode.RESOURCE_EXHAUSTED\n\tdetails = "details3"\n\tdebug_error_string = "None"\n>\n'):
+        GrpcChannelBuilder().for_address("myServer.myDomain", 9999)._test_connection(channel, True)
+    mock_getMetadata.assert_has_calls(
+        [call(GetMetadataRequest(), wait_for_ready=False),
+         call(GetMetadataRequest(), wait_for_ready=False),
+         call(GetMetadataRequest(), wait_for_ready=False)]
+    )
+    assert mock_getMetadata.call_count == 3


### PR DESCRIPTION
# Description

Newly created grpc channels don't report any type of connection error until a grpc request is actually attempted. This PR attempts a getMetadata() grpc request on any newly created grpc channels and on failure throws an exception rather than returning an unusable channel to the user. 



# Associated tasks

Relies on  https://github.com/zepben/evolve-sdk-python/pull/135

Jvm sdk equivalent https://github.com/zepben/evolve-sdk-jvm/pull/150

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).
      
### Documentation
- [x] I have updated the changelog.
- [ ] I have updated any documentation required for these changes.

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

GrpcChannelBuilder requires the server it's connecting to have at least one of the following: NetwokConsumerService, CustomerConsumerService, DiagramConsumerSerivce runing and permissions to call getMetadata() on it. 

`connect_with_secret()` and `connect_with_password()` will no longer create a `ZepbenTokenFetcher` directly from kwargs.

