### PR TITLE
EWB-4143 Update Assigning Feeder Head Terminal to Match JVM SDK

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@ are encountered but no successful response is received from the known services, 
 
 ### Fixes
 * `SetDirection` now traces through non-substation transformers.
+* `Feeder.normal_head_terminal` can now be freely updated when the `Feeder` has no equipment assigned to it.
 
 ### Notes
 * None.

--- a/src/zepben/evolve/model/cim/iec61970/base/core/equipment_container.py
+++ b/src/zepben/evolve/model/cim/iec61970/base/core/equipment_container.py
@@ -240,10 +240,11 @@ class Feeder(EquipmentContainer):
 
     @normal_head_terminal.setter
     def normal_head_terminal(self, term: Optional[Terminal]):
-        if self._normal_head_terminal is None or self._normal_head_terminal is term:
+        if self._normal_head_terminal is None or self._normal_head_terminal is term or (self.num_equipment() == 0 and self.num_current_equipment() == 0):
             self._normal_head_terminal = term
         else:
-            raise ValueError(f"normal_head_terminal for {str(self)} has already been set to {self._normal_head_terminal}, cannot reset this field to {term}")
+            raise ValueError(f"Feeder {self.mrid} has equipment assigned to it. Cannot update normalHeadTerminal on a feeder with equipment assigned.")
+
 
     @property
     def current_equipment(self) -> Generator[Equipment, None, None]:

--- a/test/cim/iec61970/base/core/test_feeder.py
+++ b/test/cim/iec61970/base/core/test_feeder.py
@@ -3,13 +3,14 @@
 #  This Source Code Form is subject to the terms of the Mozilla Public
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from pytest import raises
 from hypothesis import given
 from hypothesis.strategies import builds, lists
 
 from cim.collection_validator import validate_collection_unordered
 from cim.iec61970.base.core.test_equipment_container import equipment_container_kwargs, verify_equipment_container_constructor_default, \
     verify_equipment_container_constructor_kwargs, verify_equipment_container_constructor_args, equipment_container_args
-from zepben.evolve import Feeder, Terminal, Substation, Equipment, LvFeeder
+from zepben.evolve import Feeder, Terminal, Substation, Equipment, LvFeeder, Switch
 
 feeder_kwargs = {
     **equipment_container_kwargs,
@@ -77,3 +78,69 @@ def test_normal_energized_lv_feeder_collection():
                                   Feeder.remove_normal_energized_lv_feeder,
                                   Feeder.clear_normal_energized_lv_feeders,
                                   KeyError)
+
+
+def test_can_update_normal_head_terminal_on_empty_feeder():
+    empty_feeder = Feeder()
+    terminal1 = Terminal()
+    terminal2 = Terminal()
+
+    empty_feeder.normal_head_terminal = terminal1
+    assert empty_feeder.normal_head_terminal == terminal1
+
+    empty_feeder.normal_head_terminal = terminal2
+    assert empty_feeder.normal_head_terminal == terminal2
+
+    empty_feeder.normal_head_terminal = None
+    assert empty_feeder.normal_head_terminal is None
+
+    equipment = Switch()
+    empty_feeder.add_equipment(equipment).add_current_equipment(equipment)
+    empty_feeder.clear_equipment().clear_current_equipment()
+
+    empty_feeder.normal_head_terminal = terminal1
+    assert empty_feeder.normal_head_terminal == terminal1
+
+
+def test_block_normal_head_terminal_update_when_equipment_assigned():
+    feeder = Feeder(mrid="fdr")
+    terminal1 = Terminal()
+    terminal2 = Terminal()
+
+    equipment = Switch()
+
+    feeder.add_equipment(equipment)
+
+    # allows initial assignment
+    feeder.normal_head_terminal = terminal1
+    assert feeder.normal_head_terminal == terminal1
+
+    # doesn't raise exception on trying to reassign the same terminal
+    feeder.normal_head_terminal = terminal1
+    assert feeder.normal_head_terminal == terminal1
+
+    with raises(ValueError, match="Feeder fdr has equipment assigned to it. Cannot update normalHeadTerminal on a feeder with equipment assigned."):
+        feeder.normal_head_terminal = terminal2
+    assert feeder.normal_head_terminal == terminal1
+
+
+def test_block_normal_head_terminal_update_when_current_equipment_assigned():
+    feeder = Feeder(mrid="fdr")
+    terminal1 = Terminal()
+    terminal2 = Terminal()
+
+    equipment = Switch()
+
+    feeder.add_current_equipment(equipment)
+
+    # allows initial assignment
+    feeder.normal_head_terminal = terminal1
+    assert feeder.normal_head_terminal == terminal1
+
+    # doesn't raise exception on trying to reassign the same terminal
+    feeder.normal_head_terminal = terminal1
+    assert feeder.normal_head_terminal == terminal1
+
+    with raises(ValueError, match="Feeder fdr has equipment assigned to it. Cannot update normalHeadTerminal on a feeder with equipment assigned."):
+        feeder.normal_head_terminal = terminal2
+    assert feeder.normal_head_terminal == terminal1


### PR DESCRIPTION
# Description

Update the assign feeder head terminal behaviour in the Python SDK to match the JVM SDK. 

The difference being that the JVM SDK allows updating/re-assigning (after initial assignment) of the feeder head terminal when the feeder contains no equipment(or current equipment)

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).
      
### Documentation
- [x] I have updated the changelog.
- [ ] I have updated any documentation required for these changes. 
- [ ] Something about updating the python sdk example version number/I cant remember/don't know how versioning works?

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.
