### PR TITLE
Added support for passing the grpc channel configuration options to the `GrpcChannelBuilder`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ dmypy.json
 .pyre/
 
 /todo.md
+docs/node_modules
+docs/build

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 
 ### New Features
 * Added support for `getMetadata()` gRPC calls on `CustomerConsumerClient`, `DiagramConsumerClient`, and `NetworkConsumerClient`.
+* Added support for passing the grpc channel configuration options to the `GrpcChannelBuilder`.
 
 ### Enhancements
 * `GrpcChannelBuilder` tests the connectivity of newly created channels before returning them to the user. This is done by calling `getMetadata()` against all
@@ -16,7 +17,7 @@ are encountered but no successful response is received from the known services, 
 * `Feeder.normal_head_terminal` can now be freely updated when the `Feeder` has no equipment assigned to it.
 
 ### Notes
-* None.
+* Default grpc channel message size is now 20MB.
 
 ## [0.37.0] - 2023-11-14
 ### Breaking Changes


### PR DESCRIPTION
* Default grpc channel message size is now 20MB.

# Description
We need to be able to pass configuration grpc channel options to control things like for example the max message size. This PR adds support for this.

# Associated tasks
NONE

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [X] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [X] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [X] I have commented my code in any hard-to-understand or hacky areas.
- [X] I have handled all new warnings generated by the compiler or IDE.
- [X] I have rebased onto the target branch (usually main).
      
### Documentation
- [X] I have updated the changelog.
~- [ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [X] I have considered if this is a breaking change and will communicate it with other team members if so.

This is not a breaking change.