### PR TITLE
Added support for passing the grpc channel configuration options to the `GrpcChannelBuilder`. (#145)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ dmypy.json
 .pyre/
 
 /todo.md
+docs/node_modules
+docs/build

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 * None.
 
 ### New Features
-* None.
+* Added support for passing the grpc channel configuration options to the `GrpcChannelBuilder`.
 
 ### Enhancements
 * None.
@@ -13,7 +13,7 @@
 * None.
 
 ### Notes
-* None.
+* Default grpc channel message size is now 20MB.
 
 ## [0.37.1] - 2024-01-16
 ### Fixes

--- a/test/streaming/grpc/test_grpc_channel_builder.py
+++ b/test/streaming/grpc/test_grpc_channel_builder.py
@@ -7,10 +7,14 @@ from zepben.auth import ZepbenTokenFetcher
 
 from zepben.evolve import GrpcChannelBuilder
 
+_TWENTY_MEGABYTES = 1024 * 1024 * 20
+DEFAULT_GRPC_CHANNEL_MAX_RECEIVE_MESSAGE_LENGTH = ("grpc.max_receive_message_length", _TWENTY_MEGABYTES)
+DEFAULT_GRPC_CHANNEL_MAX_SEND_MESSAGE_LENGTH = ("grpc.max_send_message_length", _TWENTY_MEGABYTES)
+DEFAULT_GRPC_CHANNEL_OPTIONS = [DEFAULT_GRPC_CHANNEL_MAX_RECEIVE_MESSAGE_LENGTH, DEFAULT_GRPC_CHANNEL_MAX_SEND_MESSAGE_LENGTH]
+
 
 @dataclass
 class MockReadable:
-
     contents: bytes
 
     def __enter__(self):
@@ -27,7 +31,36 @@ class MockReadable:
 def test_for_address(mock_insecure_channel):
     assert GrpcChannelBuilder().for_address("hostname", 1234).build() == "insecure channel"
 
-    mock_insecure_channel.assert_called_once_with("hostname:1234")
+    mock_insecure_channel.assert_called_once_with("hostname:1234", options=DEFAULT_GRPC_CHANNEL_OPTIONS)
+
+
+@mock.patch("grpc.aio.insecure_channel", return_value="insecure channel")
+def test_options_passed_to_insecure_channel(mock_insecure_channel, *_):
+    options = [("grpc.max_receive_message_length", 1), ("other_option", 1)]
+    assert GrpcChannelBuilder().for_address("hostname", 1234).build(options=options) == "insecure channel"
+    mock_insecure_channel.assert_called_once_with("hostname:1234", options=options)
+
+
+@mock.patch("grpc.ssl_channel_credentials", return_value="channel creds")
+@mock.patch("grpc.aio.secure_channel", return_value="secure channel")
+def test_options_passed_to_secure_channel(mocked_secure_channel, *_):
+    options = [("grpc.max_receive_message_length", 1), ("other_option", 0)]
+    assert GrpcChannelBuilder().for_address("hostname", 1234).make_secure_with_bytes().build(options=options) == "secure channel"
+    mocked_secure_channel.assert_called_with("hostname:1234", "channel creds", options=options)
+
+
+@mock.patch("grpc.aio.insecure_channel", return_value="insecure channel")
+def test_passed_options_override_defaults(mock_insecure_channel, *_):
+    options = [("grpc.max_receive_message_length", 1), ("other_option", 0)]
+    assert GrpcChannelBuilder().for_address("hostname", 1234).build(options=options) == "insecure channel"
+    mock_insecure_channel.assert_called_once_with("hostname:1234", options=options)
+    for option_key, option_value in mock_insecure_channel.call_args_list[0][1]["options"]:
+        if option_key == "grpc.max_receive_message_length":
+            assert option_value == 1
+        if option_key == "grpc.max_send_message_length":
+            assert option_value == _TWENTY_MEGABYTES
+        if option_key == "other_option":
+            assert option_value == 0
 
 
 @mock.patch("grpc.ssl_channel_credentials", return_value="channel creds")
@@ -37,7 +70,7 @@ def test_make_secure(mocked_secure_channel, mocked_ssl_channel_creds):
     assert GrpcChannelBuilder().for_address("hostname", 1234).make_secure_with_bytes().build() == "secure channel"
 
     mocked_ssl_channel_creds.assert_has_calls([call(b"ca", b"pk", b"cc"), call(None, None, None)])
-    mocked_secure_channel.assert_called_with("hostname:1234", "channel creds")
+    mocked_secure_channel.assert_called_with("hostname:1234", "channel creds", options=DEFAULT_GRPC_CHANNEL_OPTIONS)
 
 
 @mock.patch("builtins.open", side_effect=lambda filename, *args, **kwargs: MockReadable(str.encode(filename)))
@@ -60,7 +93,7 @@ def test_with_token_fetcher(mocked_ssl_channel_creds, mocked_md_call_creds, mock
     mocked_ssl_channel_creds.assert_called_once()
     mocked_md_call_creds.assert_called_once()
     mocked_comp_channel_creds.assert_called_once_with("ssl creds", "call creds")
-    mocked_secure_channel.assert_called_once_with("hostname:1234", "composite creds")
+    mocked_secure_channel.assert_called_once_with("hostname:1234", "composite creds", options=DEFAULT_GRPC_CHANNEL_OPTIONS)
 
 
 def test_with_token_fetcher_before_make_secure():


### PR DESCRIPTION

* Default grpc channel message size is now 20MB.
Signed-off-by: Roberto Marquez <roberto.marquez@zepben.com>
Signed-off-by: Kurt Greaves <kurt.greaves@zepben.com>
Co-authored-by: Kurt Greaves <kurt.greaves@zepben.com>

(cherry picked from commit 74c3457dca02cf073e916ebddb9ce1cf553cf21b)
Signed-off-by: Roberto Marquez <roberto.marquez@zepben.com>

# Description

This PR cherrypicks the changes from main that add support for passing in grpc channel options.

# Associated tasks
NONE

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [X] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [X] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [X] I have commented my code in any hard-to-understand or hacky areas.
- [X] I have handled all new warnings generated by the compiler or IDE.
- [X] I have rebased onto the target branch (usually main).
      
### Documentation
- [X] I have updated the changelog.
~- [ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [X] I have considered if this is a breaking change and will communicate it with other team members if so.

Not a breaking change.