### PR TITLE
DEV-249 Include PotentialTransformers in serialized types list

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@ are encountered but no successful response is received from the known services, 
 ### Fixes
 * `SetDirection` now traces through non-substation transformers.
 * `Feeder.normal_head_terminal` can now be freely updated when the `Feeder` has no equipment assigned to it.
+* `PotentialTransformer` now recognised as a valid identified object type when deserializing gRPC messages.
 
 ### Notes
 * Default grpc channel message size is now 20MB.

--- a/src/zepben/evolve/streaming/get/network_consumer.py
+++ b/src/zepben/evolve/streaming/get/network_consumer.py
@@ -27,7 +27,7 @@ from zepben.evolve import NetworkService, Feeder, IdentifiedObject, CableInfo, O
     PowerElectronicsConnectionPhase, BatteryUnit, PhotoVoltaicUnit, PowerElectronicsWindUnit, BusbarSection, LoadBreakSwitch, TransformerTankInfo, \
     TransformerEndInfo, TransformerStarImpedance, EquipmentContainer, NetworkHierarchy, MultiObjectResult, CimConsumerClient, NoLoadTest, OpenCircuitTest, \
     ShortCircuitTest, EquivalentBranch, ShuntCompensatorInfo, LvFeeder, CurrentRelay, CurrentTransformer, CurrentRelayInfo, SwitchInfo, \
-    CurrentTransformerInfo, EvChargingUnit, TapChangerControl, ServiceInfo
+    CurrentTransformerInfo, EvChargingUnit, TapChangerControl, ServiceInfo, PotentialTransformer, PotentialTransformerInfo
 from zepben.evolve.streaming.grpc.grpc import GrpcResult
 
 __all__ = ["NetworkConsumerClient", "SyncNetworkConsumerClient"]
@@ -666,8 +666,14 @@ _nio_type_to_cim = {
     # IEC61968 OPERATIONS #
     "operationalRestriction": OperationalRestriction,
 
+    # IEC61968 InfIEC61968 ASSET INFO #
+    "currentTransformerInfo": CurrentTransformerInfo,
+    "potentialTransformerInfo": PotentialTransformerInfo,
+
     # IEC61970 BASE AUXILIARY EQUIPMENT #
+    "currentTransformer": CurrentTransformer,
     "faultIndicator": FaultIndicator,
+    "potentialTransformer": PotentialTransformer,
 
     # IEC61970 BASE CORE #
     "baseVoltage": BaseVoltage,
@@ -728,8 +734,6 @@ _nio_type_to_cim = {
     "currentRelay": CurrentRelay,
     "currentRelayInfo": CurrentRelayInfo,
     "switchInfo": SwitchInfo,
-    "currentTransformer": CurrentTransformer,
-    "currentTransformerInfo": CurrentTransformerInfo,
 
     # IEC61970 InfIEC61970 WIRES GENERATION PRODUCTION #
     "evChargingUnit": EvChargingUnit

--- a/test/streaming/get/pb_creators.py
+++ b/test/streaming/get/pb_creators.py
@@ -1330,8 +1330,14 @@ def network_identified_objects(draw):
         # IEC61968 OPERATIONS #
         draw(builds(NetworkIdentifiedObject, operationalRestriction=operational_restriction())),
 
+        # IEC61968 InfIEC61968 ASSET INFO #
+        draw(builds(NetworkIdentifiedObject, currentTransformerInfo=current_transformer_info())),
+        draw(builds(NetworkIdentifiedObject, potentialTransformerInfo=potential_transformer_info())),
+
         # IEC61970 BASE AUXILIARY EQUIPMENT #
+        draw(builds(NetworkIdentifiedObject, currentTransformer=current_transformer())),
         draw(builds(NetworkIdentifiedObject, faultIndicator=fault_indicator())),
+        draw(builds(NetworkIdentifiedObject, potentialTransformer=potential_transformer())),
 
         # IEC61970 BASE CORE #
         draw(builds(NetworkIdentifiedObject, baseVoltage=base_voltage())),


### PR DESCRIPTION
# Description

Fixed issue where `PotentialTransformer`'s couldn't be deserialized from gRPC/protobuf messages because the type was missing from the `_nio_type_to_cim` list.

If you have added new dependencies to the project please state why. 

# Associated tasks

No other work required

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
~- [] I have commented my code in any hard-to-understand or hacky areas.~
~- [ ] I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).
      
### Documentation
- [x] I have updated the changelog.
- [x] I have updated any documentation required for these changes.

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

Fix only allows additional functionality. Shouldn't prevent or change any existing behaviour.

