### PR TITLE
[DEV-3988] Added test from JVM for LV feeder energisation in the current state (wasn't broken here).

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,7 @@
 
 ## [1.0.0] - 2025-08-28
 ### Breaking Changes
+* Removed support for Python 3.9. Upgrade your Python environment to at least 3.10.
 * Renamed the package to `zepben.ewb`. You will need to update all your imports `zepben.evolve.*` -> `zepben.ewb.*`. This also updates the pypi artifact to
   `zepben.ewb`.
 * Renamed `length_from_t1_or_0` to `length_from_t1_or_0`.

--- a/docs/src/pages/release-notes.md
+++ b/docs/src/pages/release-notes.md
@@ -71,6 +71,7 @@ a 1.0.0 release.
 
 ## [1.0.0] - 2025-08-28
 ### Breaking Changes
+* Removed support for Python 3.9. Upgrade your Python environment to at least 3.10.
 * Renamed the package to `zepben.ewb`. You will need to update all your imports `zepben.evolve.*` -> `zepben.ewb.*`. This also updates the pypi artifact to
   `zepben.ewb`.
 * Renamed `length_from_t1_or_0` to `length_from_t1_or_0`.

--- a/test/services/network/tracing/test_assign_to_lv_feeders.py
+++ b/test/services/network/tracing/test_assign_to_lv_feeders.py
@@ -2,7 +2,7 @@
 #  This Source Code Form is subject to the terms of the Mozilla Public
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
-from typing import Iterable
+from typing import Iterable, Type
 
 import pytest
 from zepben.ewb import Equipment, TestNetworkBuilder, BaseVoltage, LvFeeder, NetworkStateOperators, CurrentTransformer, ProtectedSwitch, CurrentRelay, ProtectionRelayScheme, ProtectionRelaySystem, PhotoVoltaicUnit, PowerElectronicsConnection, ConductingEquipment, Breaker
@@ -275,65 +275,68 @@ class TestAssignToLvFeeders:
 
     @pytest.mark.asyncio
     async def test_lv_feeders_detect_back_feeds_for_dist_substation_sites(self):
-        #
-        #                1--c2--21 b3 2
-        # 1 tx0 21--c1--2
-        #                1--c4--21 b5 21--c6--21 b7 2
-        #
-        network = (TestNetworkBuilder()
-                   .from_power_transformer(end_actions=[lambda t: setattr(t, 'rated_u', self.bv_hv.nominal_voltage), lambda t: setattr(t, 'rated_u', self.bv_lv.nominal_voltage)])  # tx0
-                   .to_acls(action=self._make_lv)  # c1
-                   .to_acls(action=self._make_lv)  # c2
-                   .to_breaker(action=self._make_lv)  # b3
-                   .from_acls(action=self._make_lv)  # c4
-                   .to_breaker(action=self._make_lv)  # b5
-                   .to_acls(action=self._make_lv)  # c6
-                   .to_breaker(action=self._make_lv)  # b7
-                   .connect('c1', 'c4', 2, 1)
-                   .add_lv_feeder('tx0')  # lvf8
-                   .add_lv_feeder('b3')  # lvf9
-                   .add_lv_feeder('b5')  # lvf10
-                   .add_lv_feeder('b7', 1)  # lvf11
-                   .add_site(['tx0', 'c1', 'c2', 'b3', 'c4', 'b5'])  # site12
-                   ).network
+        async def run_with_operators(operators: Type[NetworkStateOperators]):
+            #
+            #                1--c2--21 b3 2
+            # 1 tx0 21--c1--2
+            #                1--c4--21 b5 21--c6--21 b7 2
+            #
+            network = (TestNetworkBuilder()
+                       .from_power_transformer(end_actions=[lambda t: setattr(t, 'rated_u', self.bv_hv.nominal_voltage), lambda t: setattr(t, 'rated_u', self.bv_lv.nominal_voltage)])  # tx0
+                       .to_acls(action=self._make_lv)  # c1
+                       .to_acls(action=self._make_lv)  # c2
+                       .to_breaker(action=self._make_lv)  # b3
+                       .from_acls(action=self._make_lv)  # c4
+                       .to_breaker(action=self._make_lv)  # b5
+                       .to_acls(action=self._make_lv)  # c6
+                       .to_breaker(action=self._make_lv)  # b7
+                       .connect('c1', 'c4', 2, 1)
+                       .add_lv_feeder('tx0')  # lvf8
+                       .add_lv_feeder('b3')  # lvf9
+                       .add_lv_feeder('b5')  # lvf10
+                       .add_lv_feeder('b7', 1)  # lvf11
+                       .add_site(['tx0', 'c1', 'c2', 'b3', 'c4', 'b5'])  # site12
+                       ).network
 
-        operators = NetworkStateOperators.NORMAL
-        b7: Breaker = network['b7']
+            b7: Breaker = network['b7']
 
-        feeder = Feeder()
-        lv_feeder8 = network['lvf8']
-        operators.associate_energizing_feeder(feeder, lv_feeder8)
-        lv_feeder9 = network['lvf9']
-        operators.associate_energizing_feeder(feeder, lv_feeder9)
-        lv_feeder10 = network['lvf10']
-        operators.associate_energizing_feeder(feeder, lv_feeder10)
-        
-        # We create an LV feeder to assign from b7 with its associated energizing feeder, which we will test is assigned to all LV feeders
-        # in the dist substation site, not just the one on b5.
-        back_feed = Feeder()
-        lv_feeder = LvFeeder()
-        operators.associate_energizing_feeder(back_feed, lv_feeder)
+            feeder = Feeder()
+            lv_feeder8 = network['lvf8']
+            operators.associate_energizing_feeder(feeder, lv_feeder8)
+            lv_feeder9 = network['lvf9']
+            operators.associate_energizing_feeder(feeder, lv_feeder9)
+            lv_feeder10 = network['lvf10']
+            operators.associate_energizing_feeder(feeder, lv_feeder10)
 
-        await Tracing.assign_equipment_to_lv_feeders().run(
-            b7.get_terminal_by_sn(1),
-            network.lv_feeder_start_points,
-            {},
-            [lv_feeder],
-            operators
-        )
+            # We create an LV feeder to assign from b7 with its associated energizing feeder, which we will test is assigned to all LV feeders
+            # in the dist substation site, not just the one on b5.
+            back_feed = Feeder()
+            lv_feeder = LvFeeder()
+            operators.associate_energizing_feeder(back_feed, lv_feeder)
 
-        # Make sure the LV feeder trace stopped at the first LV feeder head.
-        assert [it.mrid for it in lv_feeder.equipment] == ['b7', 'c6', 'b5']
+            await Tracing.assign_equipment_to_lv_feeders().run(
+                b7.get_terminal_by_sn(1),
+                network.lv_feeder_start_points,
+                {},
+                [lv_feeder],
+                operators
+            )
 
-        # Make sure both feeders are now considered to be energizing all LV feeders.
-        assert list(feeder.normal_energized_lv_feeders) == [lv_feeder8, lv_feeder9, lv_feeder10, lv_feeder]
-        assert list(back_feed.normal_energized_lv_feeders) == [lv_feeder, lv_feeder8, lv_feeder9, lv_feeder10]
+            # Make sure the LV feeder trace stopped at the first LV feeder head.
+            assert [it.mrid for it in operators.get_equipment(lv_feeder)] == ['b7', 'c6', 'b5']
 
-        # Make sure all LV feeders are now considered to be energized by both feeders.
-        assert list(lv_feeder.normal_energizing_feeders) == [back_feed, feeder]
-        assert list(lv_feeder8.normal_energizing_feeders) == [feeder, back_feed]
-        assert list(lv_feeder9.normal_energizing_feeders) == [feeder, back_feed]
-        assert list(lv_feeder10.normal_energizing_feeders) == [feeder, back_feed]
+            # Make sure both feeders are now considered to be energizing all LV feeders.
+            assert list(operators.get_energized_lv_feeders(feeder)) == [lv_feeder8, lv_feeder9, lv_feeder10, lv_feeder]
+            assert list(operators.get_energized_lv_feeders(back_feed)) == [lv_feeder, lv_feeder8, lv_feeder9, lv_feeder10]
+
+            # Make sure all LV feeders are now considered to be energized by both feeders.
+            assert list(operators.get_energizing_feeders(lv_feeder)) == [back_feed, feeder]
+            assert list(operators.get_energizing_feeders(lv_feeder8)) == [feeder, back_feed]
+            assert list(operators.get_energizing_feeders(lv_feeder9)) == [feeder, back_feed]
+            assert list(operators.get_energizing_feeders(lv_feeder10)) == [feeder, back_feed]
+
+        await run_with_operators(operators = NetworkStateOperators.NORMAL)
+        await run_with_operators(operators = NetworkStateOperators.CURRENT)
 
     @pytest.mark.asyncio
     async def test_assigns_normal_and_current_energising_feeders_based_on_state(self):


### PR DESCRIPTION
# Description

Added missing breaking change note for Python 3.10 and added test from JVM for LV feeder energisation in the current state (wasn't broken here).

# Associated tasks

- https://github.com/zepben/ewb-sdk-jvm/pull/239

# Test Steps

Unit tests.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
~- [ ] I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).

### Security
When developing applications, use following guidelines for information security considerations:
* Access to applications should be protected with security keys/tokens or usernames and passwords;
* All sessions are encrypted if possible;
* All application input is sanitised before being acted on (ie SQL statements, etc);
* Log messages, and especially client-facing ones, must be handled securely and must not leak credentials information (internal URLs, passwords, tokens).

- [x] I have considered if this change impacts information security and made sure those impacts are handled.

### Documentation
- [x] I have updated the changelog.
~- [ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.

Non-breaking