### PR TITLE
Make names test immutable

### DIFF
--- a/test/cim/iec61970/base/core/test_identified_object.py
+++ b/test/cim/iec61970/base/core/test_identified_object.py
@@ -7,7 +7,7 @@ from typing import Tuple
 
 import pytest
 
-from zepben.ewb import IdentifiedObject, generate_id
+from zepben.ewb import IdentifiedObject, generate_id, Name
 from zepben.ewb.model.cim.iec61970.base.core.name_type import NameType
 from zepben.ewb.model.cim.iec61970.base.wires.junction import Junction
 
@@ -37,11 +37,9 @@ def verify_identified_object_constructor_kwargs(io: IdentifiedObject, mrid, name
     assert io.mrid == mrid
     assert io.name == name
     assert io.description == description
-    # Assign identified object to the names we are checking against due to no identified object requirement on Name creation
-    # Note: this is due to automatic two-way association introduced in the name rejig rework
+    # Recreate expected names with the object linked, which matches IdentifiedObject constructor behaviour
     if names is not None:
-        for name in names:
-            name.identified_object = io
+        names = [Name(name=name.name, type=name.type, identified_object=io) for name in names]
         assert list(io.names) == names
     else:
         assert not list(io.names)


### PR DESCRIPTION
# Description

Changed names assertion in test_identified_object to use reinstantiation instead of attribute reassignment

# Associated tasks

None

# Test Steps

Run the test suite

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- ~[ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
- ~[ ] I have commented my code in any hard-to-understand or hacky areas.~
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Security
When developing applications, use following guidelines for information security considerations:
* Access to applications should be protected with security keys/tokens or usernames and passwords;
* All sessions are encrypted if possible;
* All application input is sanitised before being acted on (ie SQL statements, etc);
* Log messages, and especially client-facing ones, must be handled securely and must not leak credentials information (internal URLs, passwords, tokens).

- [x] I have considered if this change impacts information security and made sure those impacts are handled.

### Documentation
- [x] I have updated the changelog.
- ~[ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.

Please leave a summary of the breaking changes here and then post it on the Slack **breaking-changes** channel to notify the team about it.
