### PR TITLE
DEV-9690 Ensure all backfill fields are @property; Mark their setters as depre…

### DIFF
--- a/src/zepben/ewb/model/cim/iec61970/base/core/feeder.py
+++ b/src/zepben/ewb/model/cim/iec61970/base/core/feeder.py
@@ -9,6 +9,8 @@ __all__ = ["Feeder"]
 
 from typing import Optional, Dict, List, Generator, TYPE_CHECKING
 
+from typing_extensions import deprecated
+
 from zepben.ewb import get_by_mrid
 from zepben.ewb.model.cim.extensions.zbex import zbex
 from zepben.ewb.model.cim.iec61970.base.core.equipment_container import EquipmentContainer
@@ -33,8 +35,7 @@ class Feeder(EquipmentContainer):
     _normal_head_terminal: Terminal | None = None
     """The normal head terminal or terminals of the feeder."""
 
-    normal_energizing_substation: Substation | None = None
-    """The substation that normally energizes the feeder. Also used for naming purposes."""
+    _normal_energizing_substation: Substation | None = None
 
     _current_equipment: Dict[str, Equipment] | None = None
     """The equipment contained in this feeder in the current state of the network."""
@@ -92,6 +93,16 @@ class Feeder(EquipmentContainer):
             self._normal_head_terminal = term
         else:
             raise ValueError(f"Feeder {self.mrid} has equipment assigned to it. Cannot update normalHeadTerminal on a feeder with equipment assigned.")
+
+    @property
+    def normal_energizing_substation(self):
+        """The substation that normally energizes the feeder. Also used for naming purposes."""
+        return self._normal_energizing_substation
+
+    @normal_energizing_substation.setter
+    @deprecated("normal_energizing_substation should never be set directly - it is automatically set when adding it to the `feeders` list")
+    def normal_energizing_substation(self, value):
+        self._normal_energizing_substation = value
 
     @property
     def current_equipment(self) -> Generator[Equipment, None, None]:

--- a/src/zepben/ewb/model/cim/iec61970/base/core/sub_geographical_region.py
+++ b/src/zepben/ewb/model/cim/iec61970/base/core/sub_geographical_region.py
@@ -9,6 +9,8 @@ __all__ = ["SubGeographicalRegion"]
 
 from typing import Optional, List, Generator, TYPE_CHECKING
 
+from typing_extensions import deprecated
+
 from zepben.ewb.model.cim.iec61970.base.core.identified_object import IdentifiedObject
 from zepben.ewb.util import nlen, ngen, get_by_mrid, safe_remove, require
 from zepben.ewb.dataclass_descriptors.dataclass_base import zb_dataclass
@@ -24,8 +26,7 @@ class SubGeographicalRegion(IdentifiedObject):
     A subset of a geographical region of a power system network model.
     """
 
-    geographical_region: Optional[GeographicalRegion] = None
-    """The geographical region to which this sub-geographical region is within."""
+    _geographical_region: Optional[GeographicalRegion] = None
 
     _substations: Optional[List[Substation]] = None
 
@@ -34,6 +35,17 @@ class SubGeographicalRegion(IdentifiedObject):
         if substations:
             for sub in substations:
                 self.add_substation(sub)
+
+
+    @property
+    def geographical_region(self):
+        """The geographical region to which this sub-geographical region is within."""
+        return self._geographical_region
+
+    @geographical_region.setter
+    @deprecated("geographical_region should never be set directly - it is automatically set when adding it to the `sub_geographical_regions` list")
+    def geographical_region(self, value):
+        self._geographical_region = value
 
     def num_substations(self) -> int:
         """

--- a/src/zepben/ewb/model/cim/iec61970/base/core/substation.py
+++ b/src/zepben/ewb/model/cim/iec61970/base/core/substation.py
@@ -9,6 +9,8 @@ __all__ = ["Substation"]
 
 from typing import Optional, Generator, List, TYPE_CHECKING
 
+from typing_extensions import deprecated
+
 from zepben.ewb.model.cim.iec61970.base.core.equipment_container import EquipmentContainer
 from zepben.ewb.util import nlen, get_by_mrid, ngen, safe_remove, require
 from zepben.ewb.dataclass_descriptors.dataclass_base import zb_dataclass
@@ -27,8 +29,7 @@ class Substation(EquipmentContainer):
     is passed for the purposes of switching or modifying its characteristics.
     """
 
-    sub_geographical_region: Optional[SubGeographicalRegion] = None
-    """The SubGeographicalRegion containing the substation."""
+    _sub_geographical_region: Optional[SubGeographicalRegion] = None
 
     _normal_energized_feeders: Optional[List[Feeder]] = None
 
@@ -52,6 +53,17 @@ class Substation(EquipmentContainer):
         if circuits:
             for circuit in circuits:
                 self.add_circuit(circuit)
+
+
+    @property
+    def sub_geographical_region(self):
+        """The SubGeographicalRegion containing the substation."""
+        return self._sub_geographical_region
+
+    @sub_geographical_region.setter
+    @deprecated("sub_geographical_region should never be set directly - it is automatically set when adding it to the `substations` list")
+    def sub_geographical_region(self, value):
+        self._sub_geographical_region = value
 
     @property
     def circuits(self) -> Generator[Circuit, None, None]:

--- a/src/zepben/ewb/model/cim/iec61970/base/core/terminal.py
+++ b/src/zepben/ewb/model/cim/iec61970/base/core/terminal.py
@@ -11,6 +11,8 @@ from typing import Optional, Generator
 from typing import TYPE_CHECKING
 from weakref import ref, ReferenceType
 
+from typing_extensions import deprecated
+
 from zepben.ewb.model.cim.iec61970.base.core.ac_dc_terminal import AcDcTerminal
 from zepben.ewb.model.cim.iec61970.base.core.feeder import Feeder
 from zepben.ewb.model.cim.iec61970.base.core.phase_code import PhaseCode
@@ -91,6 +93,7 @@ class Terminal(AcDcTerminal):
         return self._conducting_equipment
 
     @conducting_equipment.setter
+    @deprecated("conducting_equipment should never be set directly - it is automatically set when adding it to the `terminals` list")
     def conducting_equipment(self, ce):
         if self._conducting_equipment is None or self._conducting_equipment is ce:
             self._conducting_equipment = ce

--- a/src/zepben/ewb/model/cim/iec61970/base/diagramlayout/diagram_object.py
+++ b/src/zepben/ewb/model/cim/iec61970/base/diagramlayout/diagram_object.py
@@ -9,6 +9,8 @@ __all__ = ["DiagramObject"]
 
 from typing import Optional, List, Generator, Callable, TYPE_CHECKING, Any
 
+from typing_extensions import deprecated
+
 from zepben.ewb.model.cim.iec61970.base.core.identified_object import IdentifiedObject
 from zepben.ewb.model.cim.iec61970.base.diagramlayout.diagram_object_point import DiagramObjectPoint
 from zepben.ewb.util import nlen, ngen, require, safe_remove
@@ -26,7 +28,6 @@ class DiagramObject(IdentifiedObject):
     """
 
     _diagram: Optional[Diagram] = None
-    """A diagram object is part of a diagram."""
 
     identified_object_mrid: Optional[str] = None
     """The domain object to which this diagram object is associated."""
@@ -49,9 +50,11 @@ class DiagramObject(IdentifiedObject):
 
     @property
     def diagram(self):
+        """A diagram object is part of a diagram."""
         return self._diagram
 
     @diagram.setter
+    @deprecated("diagram should never be set directly - it is automatically set when adding it to the `diagram_objects` list")
     def diagram(self, diag):
         if self._diagram is None or self._diagram is diag:
             self._diagram = diag

--- a/src/zepben/ewb/model/cim/iec61970/base/wires/ac_line_segment_phase.py
+++ b/src/zepben/ewb/model/cim/iec61970/base/wires/ac_line_segment_phase.py
@@ -9,6 +9,8 @@ __all__ = ['AcLineSegmentPhase']
 
 from typing import TYPE_CHECKING
 
+from typing_extensions import deprecated
+
 from zepben.ewb.model.cim.iec61970.base.core.power_system_resource import PowerSystemResource
 from zepben.ewb.model.cim.iec61970.base.wires.single_phase_kind import SinglePhaseKind
 from zepben.ewb.model.cim.iec61968.assetinfo.wire_info import WireInfo
@@ -45,6 +47,7 @@ class AcLineSegmentPhase(PowerSystemResource):
         return self._ac_line_segment
 
     @ac_line_segment.setter
+    @deprecated("ac_line_segment should never be set directly - it is automatically set when adding it to the `phases` list")
     def ac_line_segment(self, ac_line_segment: 'AcLineSegment') -> None:
         if self._ac_line_segment is None or self._ac_line_segment is ac_line_segment:
             self._ac_line_segment = ac_line_segment

--- a/src/zepben/ewb/model/cim/iec61970/base/wires/clamp.py
+++ b/src/zepben/ewb/model/cim/iec61970/base/wires/clamp.py
@@ -7,6 +7,8 @@ __all__ = ["Clamp"]
 
 from typing import Optional, TYPE_CHECKING
 
+from typing_extensions import deprecated
+
 from zepben.ewb.model.cim.iec61970.base.core.conducting_equipment import ConductingEquipment
 from zepben.ewb.dataclass_descriptors.dataclass_base import zb_dataclass
 
@@ -24,10 +26,19 @@ class Clamp(ConductingEquipment):
     length_from_terminal_1: Optional[float] = None
     """The length to the place where the clamp is located starting from side one of the line segment, i.e. the line segment terminal with sequence number equal to 1."""
 
-    ac_line_segment: Optional['AcLineSegment'] = None
-    """The line segment to which the clamp is connected."""
+    _ac_line_segment: Optional['AcLineSegment'] = None
 
     max_terminals = 1
+
+    @property
+    def ac_line_segment(self) -> Optional['AcLineSegment']:
+        """The line segment to which the clamp is connected."""
+        return self._ac_line_segment
+
+    @ac_line_segment.setter
+    @deprecated("ac_line_segment should never be set directly - it is automatically set when adding it to the `clamps` list")
+    def ac_line_segment(self, value):
+        self._ac_line_segment = value
 
     @property
     def length_from_t1_or_0(self) -> float:

--- a/src/zepben/ewb/model/cim/iec61970/base/wires/cut.py
+++ b/src/zepben/ewb/model/cim/iec61970/base/wires/cut.py
@@ -7,6 +7,8 @@ __all__ = ["Cut"]
 
 from typing import Optional, TYPE_CHECKING
 
+from typing_extensions import deprecated
+
 from zepben.ewb.model.cim.iec61970.base.wires.switch import Switch
 from zepben.ewb.dataclass_descriptors.dataclass_base import zb_dataclass
 
@@ -30,8 +32,17 @@ class Cut(Switch):
     length_from_terminal_1: Optional[float] = None
     """The length to the place where the cut is located starting from side one of the cut line segment, i.e. the line segment Terminal with sequenceNumber equal to 1."""
 
-    ac_line_segment: Optional['AcLineSegment'] = None
-    """The line segment to which the cut is applied."""
+    _ac_line_segment: Optional['AcLineSegment'] = None
+
+    @property
+    def ac_line_segment(self) -> Optional['AcLineSegment']:
+        """The line segment to which the cut is applied."""
+        return self._ac_line_segment
+
+    @ac_line_segment.setter
+    @deprecated("ac_line_segment should never be set directly - it is automatically set when adding it to the `cuts` list")
+    def ac_line_segment(self, value):
+        self._ac_line_segment = value
 
     @property
     def length_from_t1_or_0(self) -> float:

--- a/src/zepben/ewb/model/cim/iec61970/base/wires/energy_consumer_phase.py
+++ b/src/zepben/ewb/model/cim/iec61970/base/wires/energy_consumer_phase.py
@@ -7,6 +7,8 @@ __all__ = ["EnergyConsumerPhase"]
 
 from typing import Optional, TYPE_CHECKING
 
+from typing_extensions import deprecated
+
 from zepben.ewb.model.cim.iec61970.base.core.power_system_resource import PowerSystemResource
 from zepben.ewb.model.cim.iec61970.base.wires.single_phase_kind import SinglePhaseKind
 from zepben.ewb.dataclass_descriptors.dataclass_base import zb_dataclass
@@ -51,6 +53,7 @@ class EnergyConsumerPhase(PowerSystemResource):
         return self._energy_consumer
 
     @energy_consumer.setter
+    @deprecated("energy_consumer should never be set directly - it is automatically set when adding it to the `phases` list")
     def energy_consumer(self, ec):
         if self._energy_consumer is None or self._energy_consumer is ec:
             self._energy_consumer = ec

--- a/src/zepben/ewb/model/cim/iec61970/base/wires/energy_source_phase.py
+++ b/src/zepben/ewb/model/cim/iec61970/base/wires/energy_source_phase.py
@@ -7,6 +7,8 @@ __all__ = ["EnergySourcePhase"]
 
 from typing import Optional, TYPE_CHECKING
 
+from typing_extensions import deprecated
+
 from zepben.ewb.model.cim.iec61970.base.core.power_system_resource import PowerSystemResource
 from zepben.ewb.model.cim.iec61970.base.wires.single_phase_kind import SinglePhaseKind
 from zepben.ewb.dataclass_descriptors.dataclass_base import zb_dataclass
@@ -40,6 +42,7 @@ class EnergySourcePhase(PowerSystemResource):
         return self._energy_source
 
     @energy_source.setter
+    @deprecated("energy_sounrce should never be set directly - it is automatically set when adding it to the `phases` list")
     def energy_source(self, es):
         if self._energy_source is None or self._energy_source is es:
             self._energy_source = es

--- a/src/zepben/ewb/model/cim/iec61970/base/wires/power_electronics_connection_phase.py
+++ b/src/zepben/ewb/model/cim/iec61970/base/wires/power_electronics_connection_phase.py
@@ -7,6 +7,8 @@ __all__ = ["PowerElectronicsConnectionPhase"]
 
 from typing import Optional, TYPE_CHECKING
 
+from typing_extensions import deprecated
+
 from zepben.ewb.model.cim.iec61970.base.core.power_system_resource import PowerSystemResource
 from zepben.ewb.model.cim.iec61970.base.wires.single_phase_kind import SinglePhaseKind
 from zepben.ewb.dataclass_descriptors.dataclass_base import zb_dataclass
@@ -19,8 +21,7 @@ if TYPE_CHECKING:
 class PowerElectronicsConnectionPhase(PowerSystemResource):
     """A single phase of a power electronics connection."""
 
-    power_electronics_connection: Optional['PowerElectronicsConnection'] = None
-    """The power electronics connection to which the phase belongs."""
+    _power_electronics_connection: Optional['PowerElectronicsConnection'] = None
 
     p: Optional[float] = None
     """Active power injection. Load sign convention is used, i.e. positive sign means flow into the equipment from the network."""
@@ -34,3 +35,13 @@ class PowerElectronicsConnectionPhase(PowerSystemResource):
 
     q: Optional[float] = None
     """Reactive power injection. Load sign convention is used, i.e. positive sign means flow into the equipment from the network."""
+
+    @property
+    def power_electronics_connection(self):
+        """The power electronics connection to which the phase belongs."""
+        return self._power_electronics_connection
+
+    @power_electronics_connection.setter
+    @deprecated("power_electronics_connection should never be set directly - it is automatically set when adding it to the `phases` list")
+    def power_electronics_connection(self, value):
+        self._power_electronics_connection = value


### PR DESCRIPTION
# Description

Ensure all backfill fields are @property; Mark their setters as depre…
If you have added new dependencies to the project please state why.

# Associated tasks

None

# Test Steps

Run tests

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- ~[ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Security
When developing applications, use following guidelines for information security considerations:
* Access to applications should be protected with security keys/tokens or usernames and passwords;
* All sessions are encrypted if possible;
* All application input is sanitised before being acted on (ie SQL statements, etc);
* Log messages, and especially client-facing ones, must be handled securely and must not leak credentials information (internal URLs, passwords, tokens).

- [x] I have considered if this change impacts information security and made sure those impacts are handled.

### Documentation
- ~[ ] I have updated the changelog.~
- ~[ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.

Please leave a summary of the breaking changes here and then post it on the Slack **breaking-changes** channel to notify the team about it.

# Screenshots
